### PR TITLE
refactor: replace @Transactional with programmatic transaction management

### DIFF
--- a/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/JpaOutboxLockRepository.kt
+++ b/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/JpaOutboxLockRepository.kt
@@ -4,60 +4,67 @@ import io.namastack.outbox.lock.OutboxLock
 import io.namastack.outbox.lock.OutboxLockRepository
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceException
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.interceptor.TransactionAspectSupport
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.OffsetDateTime
 
 internal open class JpaOutboxLockRepository(
     private val entityManager: EntityManager,
+    private val transactionTemplate: TransactionTemplate,
 ) : OutboxLockRepository {
+    private val newTransactionTemplate =
+        TransactionTemplate(transactionTemplate.transactionManager!!).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
     override fun findByAggregateId(aggregateId: String): OutboxLock? {
         val entity = findEntityByAggregateId(aggregateId) ?: return null
 
         return OutboxLockEntityMapper.map(entity)
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    override fun insertNew(lock: OutboxLock): OutboxLock? {
-        // this prevents unnecessary sql error logs for duplicate key errors
-        if (findEntityByAggregateId(lock.aggregateId) != null) {
-            return null
+    override fun insertNew(lock: OutboxLock): OutboxLock? =
+        newTransactionTemplate.execute { status ->
+            // this prevents unnecessary sql error logs for duplicate key errors
+            if (findEntityByAggregateId(lock.aggregateId) != null) {
+                return@execute null
+            }
+
+            try {
+                val entity = OutboxLockEntityMapper.map(lock)
+                entityManager.persist(entity)
+                entityManager.flush()
+                OutboxLockEntityMapper.map(entity)
+            } catch (_: PersistenceException) {
+                status.setRollbackOnly()
+                null
+            }
         }
 
-        return try {
-            val entity = OutboxLockEntityMapper.map(lock)
-            entityManager.persist(entity)
-            entityManager.flush()
-            OutboxLockEntityMapper.map(entity)
-        } catch (_: PersistenceException) {
-            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly()
-            null
-        }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun renew(
         aggregateId: String,
         expiresAt: OffsetDateTime,
     ): OutboxLock? =
-        try {
-            val entity = findEntityByAggregateId(aggregateId) ?: return null
+        newTransactionTemplate.execute { status ->
+            try {
+                val entity = findEntityByAggregateId(aggregateId) ?: return@execute null
 
-            entity.expiresAt = expiresAt
-            entityManager.flush()
+                entity.expiresAt = expiresAt
+                entityManager.flush()
 
-            OutboxLockEntityMapper.map(entity)
-        } catch (_: PersistenceException) {
-            TransactionAspectSupport.currentTransactionStatus().setRollbackOnly()
-            null
+                OutboxLockEntityMapper.map(entity)
+            } catch (_: PersistenceException) {
+                status.setRollbackOnly()
+                null
+            }
         }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun deleteById(aggregateId: String) {
-        entityManager
-            .find(OutboxLockEntity::class.java, aggregateId)
-            ?.let { entityManager.remove(it) }
+        newTransactionTemplate.executeWithoutResult {
+            entityManager
+                .find(OutboxLockEntity::class.java, aggregateId)
+                ?.let { entityManager.remove(it) }
+        }
     }
 
     private fun findEntityByAggregateId(aggregateId: String): OutboxLockEntity? =

--- a/namastack-outbox-jpa/src/test/kotlin/io/namastack/outbox/JpaOutboxAutoConfigurationTest.kt
+++ b/namastack-outbox-jpa/src/test/kotlin/io/namastack/outbox/JpaOutboxAutoConfigurationTest.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
 import java.time.Clock
 import javax.sql.DataSource
 
@@ -88,6 +89,9 @@ class JpaOutboxAutoConfigurationTest {
 
         @Bean
         fun dataSource(): DataSource = mockk(relaxed = true)
+
+        @Bean
+        fun transactionManager(): PlatformTransactionManager = mockk(relaxed = true)
     }
 
     @Configuration


### PR DESCRIPTION
Replace declarative transaction management (@Transactional) with programmatic approach using TransactionTemplate to support multi-persistence unit environments.

Changes:
- Remove @Transactional annotations from repository methods
- Add TransactionTemplate as constructor dependency in repositories
- Wrap transactional operations with transactionTemplate.execute()
- Create outboxTransactionTemplate bean with conditional creation
- Update JpaOutboxRecordRepository to use TransactionTemplate for save and delete operations
- Update JpaOutboxLockRepository to use TransactionTemplate with REQUIRES_NEW propagation for lock operations
- Add @ConditionalOnMissingBean(name) to allow user-defined transaction template override
- Add @ConditionalOnBean(PlatformTransactionManager) to prevent errors in non-transactional contexts
- Inject TransactionTemplate by name (outboxTransactionTemplate) to avoid ambiguity in multi-persistence scenarios
- Add PlatformTransactionManager mock to test configurations

Benefits:
- Works automatically with single persistence unit (zero configuration required)
- Allows explicit transaction manager injection for multi-persistence unit scenarios
- No dependency on AOP proxying for transactions
- Users can override outboxTransactionTemplate bean to inject specific transaction managers
- More predictable behavior in complex transaction scenarios
- Follows Spring Boot auto-configuration conventions

Migration for multi-persistence unit apps:
Users can now define their own outboxTransactionTemplate bean with a specific transaction manager, and the library will automatically use it:

```kotlin
@Bean
fun outboxTransactionTemplate(
    @Qualifier("outboxTransactionManager") txManager: PlatformTransactionManager
): TransactionTemplate = TransactionTemplate(txManager)
```