### PR TITLE
Fix: downgrade Java version to 21 to match the minimum Java requirement

### DIFF
--- a/namastack-outbox-examples/namastack-outbox-example-java/build.gradle.kts
+++ b/namastack-outbox-examples/namastack-outbox-example-java/build.gradle.kts
@@ -10,7 +10,7 @@ description = "namastack-outbox-example-java"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/namastack-outbox-examples/namastack-outbox-example-java/src/main/java/io/namastack/demo/DemoApplication.java
+++ b/namastack-outbox-examples/namastack-outbox-example-java/src/main/java/io/namastack/demo/DemoApplication.java
@@ -23,7 +23,7 @@ public class DemoApplication implements CommandLineRunner {
     this.service = service;
   }
 
-  static void main(String[] args) {
+  public static void main(String[] args) {
     SpringApplication.run(DemoApplication.class, args);
   }
 


### PR DESCRIPTION
Downgrade Java version to 21 of namastack-outbox-example-java to match the minimum Java requirement