### PR TITLE
Refactor OutboxRetryPolicy.Builder to be additive

### DIFF
--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicy.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicy.kt
@@ -336,7 +336,7 @@ interface OutboxRetryPolicy {
                 maxRetries = maxRetries,
                 backOffStrategy = backOffStrategy,
                 jitter = jitter,
-                retryableExceptions = exceptions.toList(),
+                retryableExceptions = retryableExceptions + exceptions,
                 nonRetryableExceptions = nonRetryableExceptions,
                 retryPredicate = retryPredicate,
             )
@@ -370,7 +370,7 @@ interface OutboxRetryPolicy {
                 backOffStrategy = backOffStrategy,
                 jitter = jitter,
                 retryableExceptions = retryableExceptions,
-                nonRetryableExceptions = exceptions.toList(),
+                nonRetryableExceptions = nonRetryableExceptions + exceptions,
                 retryPredicate = retryPredicate,
             )
 
@@ -383,15 +383,23 @@ interface OutboxRetryPolicy {
          * @param predicate The predicate function to evaluate exceptions
          * @return Builder instance for method chaining
          */
-        fun retryIf(predicate: Predicate<Throwable>): Builder =
-            Builder(
+        fun retryIf(predicate: Predicate<Throwable>): Builder {
+            val newPredicate =
+                if (retryPredicate != null) {
+                    retryPredicate.or(predicate)
+                } else {
+                    predicate
+                }
+
+            return Builder(
                 maxRetries = maxRetries,
                 backOffStrategy = backOffStrategy,
                 jitter = jitter,
                 retryableExceptions = retryableExceptions,
                 nonRetryableExceptions = nonRetryableExceptions,
-                retryPredicate = predicate,
+                retryPredicate = newPredicate,
             )
+        }
 
         /**
          * Builds and returns a configured [OutboxRetryPolicy] instance.

--- a/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyTest.kt
+++ b/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyTest.kt
@@ -132,6 +132,48 @@ class OutboxRetryPolicyTest {
             assertThat(policy.shouldRetry(OtherNonRetryableException())).isFalse()
             assertThat(policy.shouldRetry(UndefinedException())).isFalse()
         }
+
+        @Test
+        fun `retryOn accumulates exceptions instead of replacing them`() {
+            val policy =
+                OutboxRetryPolicy
+                    .builder()
+                    .retryOn(RetryableException::class.java)
+                    .retryOn(OtherRetryableException::class.java)
+                    .build()
+
+            assertThat(policy.shouldRetry(RetryableException())).isTrue()
+            assertThat(policy.shouldRetry(OtherRetryableException())).isTrue()
+            assertThat(policy.shouldRetry(UndefinedException())).isFalse()
+        }
+
+        @Test
+        fun `noRetryOn accumulates exceptions instead of replacing them`() {
+            val policy =
+                OutboxRetryPolicy
+                    .builder()
+                    .noRetryOn(NonRetryableException::class.java)
+                    .noRetryOn(OtherNonRetryableException::class.java)
+                    .build()
+
+            assertThat(policy.shouldRetry(NonRetryableException())).isFalse()
+            assertThat(policy.shouldRetry(OtherNonRetryableException())).isFalse()
+            assertThat(policy.shouldRetry(UndefinedException())).isTrue()
+        }
+
+        @Test
+        fun `retryIf accumulates predicates using OR logic`() {
+            val policy =
+                OutboxRetryPolicy
+                    .builder()
+                    .retryIf { it is RetryableException }
+                    .retryIf { it is OtherRetryableException }
+                    .build()
+
+            assertThat(policy.shouldRetry(RetryableException())).isTrue()
+            assertThat(policy.shouldRetry(OtherRetryableException())).isTrue()
+            assertThat(policy.shouldRetry(UndefinedException())).isFalse()
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
Refactors `OutboxRetryPolicy.Builder` to accumulate configuration instead of replacing it. This aligns with standard builder pattern expectations and allows for safer policy composition.
close #165 

## Changes
- `retryOn` / `noRetryOn`: Now appends new exceptions to the existing list instead of overwriting.
- `retryIf`: Now composites predicates using `.or()` logic. If a predicate already exists, the new one is OR-ed with it.
- Tests : Added unit tests in `OutboxRetryPolicyTest` to verify the additive behavior for all modified methods.

## Verification
- Run `OutboxRetryPolicyTest` to verify that multiple calls to `retryOn` now result in all exceptions being retryable.