### PR TITLE
Add support for Oracle database.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ postgresql = { module = "org.postgresql:postgresql" }
 mysql-connector-j = { module = "com.mysql:mysql-connector-j" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client" }
 mssql-jdbc = { module = "com.microsoft.sqlserver:mssql-jdbc" }
+oracle-jdbc = { module = "com.oracle.database.jdbc:ojdbc11" }
 
 # Test dependencies
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -71,6 +72,7 @@ testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.
 testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
 testcontainers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "testcontainers" }
 testcontainers-mssqlserver = { module = "org.testcontainers:mssqlserver", version.ref = "testcontainers" }
+testcontainers-oracle-xe = { module = "org.testcontainers:oracle-xe", version.ref = "testcontainers" }
 
 [plugins]
 # Kotlin plugins

--- a/namastack-outbox-jdbc/build.gradle.kts
+++ b/namastack-outbox-jdbc/build.gradle.kts
@@ -28,10 +28,12 @@ dependencies {
     testImplementation(libs.testcontainers.mysql)
     testImplementation(libs.testcontainers.mariadb)
     testImplementation(libs.testcontainers.mssqlserver)
+    testImplementation(libs.testcontainers.oracle.xe)
 
     testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(libs.postgresql)
     testRuntimeOnly(libs.mysql.connector.j)
     testRuntimeOnly(libs.mariadb.java.client)
     testRuntimeOnly(libs.mssql.jdbc)
+    testRuntimeOnly(libs.oracle.jdbc)
 }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/config/JdbcDatabaseType.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/config/JdbcDatabaseType.kt
@@ -15,11 +15,12 @@ package io.namastack.outbox.config
  *
  * @param schemaLocation Classpath location of the database-specific schema script
  *
- * @author Roland Beisel
+ * @author Roland Beisel, Khalid Alharisi
  * @since 1.0.0
  */
 sealed class JdbcDatabaseType(
     val schemaLocation: String,
+    val statementSeparator: String = ";",
 ) {
     /**
      * PostgreSQL database type.
@@ -71,6 +72,19 @@ sealed class JdbcDatabaseType(
         schemaLocation = "classpath:schema/sqlserver/outbox-tables.sql",
     )
 
+    /**
+     * Oracle database type.
+     *
+     * Oracle Database is a high-performance, converged relational database designed to handle
+     * complex enterprise workloads.
+     *
+     * The minimum supported Oracle Database version is 18c. Older versions may work, but they are not tested.
+     */
+    data object Oracle : JdbcDatabaseType(
+        schemaLocation = "classpath:schema/oracle/outbox-tables.sql",
+        statementSeparator = "/",
+    )
+
     companion object {
         /**
          * Resolves a database type from its name.
@@ -89,6 +103,7 @@ sealed class JdbcDatabaseType(
                 "h2" -> H2
                 "mariadb" -> MariaDB
                 "microsoft sql server" -> SQLServer
+                "oracle" -> Oracle
                 else -> throw IllegalArgumentException("Unsupported database type: $databaseName")
             }
     }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/config/JdbcOutboxSchemaAutoConfiguration.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/config/JdbcOutboxSchemaAutoConfiguration.kt
@@ -17,7 +17,7 @@ import javax.sql.DataSource
  * This configuration handles database schema creation when enabled.
  * Requires a DataSource to be present.
  *
- * @author Roland Beisel
+ * @author Roland Beisel, Khalid Alharisi
  * @since 1.0.0
  */
 @AutoConfiguration
@@ -49,6 +49,7 @@ class JdbcOutboxSchemaAutoConfiguration {
 
         val settings = DatabaseInitializationSettings()
         settings.schemaLocations = mutableListOf(databaseType.schemaLocation)
+        settings.separator = databaseType.statementSeparator
         settings.mode = DatabaseInitializationMode.ALWAYS
 
         return DataSourceScriptDatabaseInitializer(dataSource, settings)

--- a/namastack-outbox-jdbc/src/main/resources/schema/oracle/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/oracle/outbox-tables.sql
@@ -1,0 +1,77 @@
+-- OUTBOX_RECORD
+DECLARE
+    v_count NUMBER;
+BEGIN
+    SELECT count(*) INTO v_count FROM user_tables WHERE table_name = 'OUTBOX_RECORD';
+    IF v_count = 0 THEN
+        EXECUTE IMMEDIATE '
+            CREATE TABLE outbox_record
+            (
+                id             VARCHAR2(255) NOT NULL,
+                status         VARCHAR2(20) NOT NULL,
+                record_key     VARCHAR2(255) NOT NULL,
+                record_type    VARCHAR2(255) NOT NULL,
+                payload        NCLOB NOT NULL,
+                context        NCLOB,
+                created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+                completed_at   TIMESTAMP WITH TIME ZONE,
+                failure_count  NUMBER(10) NOT NULL,
+                failure_reason VARCHAR2(1000),
+                next_retry_at  TIMESTAMP WITH TIME ZONE NOT NULL,
+                partition_no   NUMBER(10) NOT NULL,
+                handler_id     VARCHAR2(1000) NOT NULL,
+                PRIMARY KEY (id)
+            )';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_rec_key_cr ON outbox_record (record_key, created_at)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_rec_p_s_r ON outbox_record (partition_no, status, next_retry_at)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_rec_s_r ON outbox_record (status, next_retry_at)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_rec_stat ON outbox_record (status)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_rec_k_c_c ON outbox_record (record_key, completed_at, created_at)';
+    END IF;
+END;
+/
+
+-- OUTBOX_INSTANCE
+DECLARE
+    v_count NUMBER;
+BEGIN
+    SELECT count(*) INTO v_count FROM user_tables WHERE table_name = 'OUTBOX_INSTANCE';
+    IF v_count = 0 THEN
+        EXECUTE IMMEDIATE '
+            CREATE TABLE outbox_instance
+            (
+                instance_id    VARCHAR2(255) PRIMARY KEY,
+                hostname       VARCHAR2(255) NOT NULL,
+                port           NUMBER(10) NOT NULL,
+                status         VARCHAR2(50) NOT NULL,
+                started_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+                last_heartbeat TIMESTAMP WITH TIME ZONE NOT NULL,
+                created_at     TIMESTAMP WITH TIME ZONE NOT NULL,
+                updated_at     TIMESTAMP WITH TIME ZONE NOT NULL
+            )';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_inst_s_h ON outbox_instance (status, last_heartbeat)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_inst_l_h ON outbox_instance (last_heartbeat)';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_inst_stat ON outbox_instance (status)';
+    END IF;
+END;
+/
+
+-- OUTBOX_PARTITION
+DECLARE
+    v_count NUMBER;
+BEGIN
+    SELECT count(*) INTO v_count FROM user_tables WHERE table_name = 'OUTBOX_PARTITION';
+    IF v_count = 0 THEN
+        EXECUTE IMMEDIATE '
+            CREATE TABLE outbox_partition
+            (
+                partition_number NUMBER(10) PRIMARY KEY,
+                instance_id      VARCHAR2(255),
+                version          NUMBER(19) DEFAULT 0 NOT NULL,
+                updated_at       TIMESTAMP WITH TIME ZONE NOT NULL
+            )';
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_part_inst_id ON outbox_partition (instance_id)';
+    END IF;
+END;
+/
+

--- a/namastack-outbox-jdbc/src/test/kotlin/io/namastack/outbox/config/JdbcDatabaseTypeTest.kt
+++ b/namastack-outbox-jdbc/src/test/kotlin/io/namastack/outbox/config/JdbcDatabaseTypeTest.kt
@@ -51,6 +51,16 @@ class JdbcDatabaseTypeTest {
     }
 
     @Nested
+    inner class OracleTest {
+        @Test
+        fun `has correct schema location`() {
+            assertThat(
+                JdbcDatabaseType.Oracle.schemaLocation,
+            ).isEqualTo("classpath:schema/oracle/outbox-tables.sql")
+        }
+    }
+
+    @Nested
     inner class FromTest {
         @Test
         fun `returns PostgreSQL type for postgresql input`() {
@@ -84,6 +94,13 @@ class JdbcDatabaseTypeTest {
             assertThat(JdbcDatabaseType.from("microsoft sql server")).isEqualTo(JdbcDatabaseType.SQLServer)
             assertThat(JdbcDatabaseType.from("MICROSOFT SQL SERVER")).isEqualTo(JdbcDatabaseType.SQLServer)
             assertThat(JdbcDatabaseType.from("Microsoft SQL Server")).isEqualTo(JdbcDatabaseType.SQLServer)
+        }
+
+        @Test
+        fun `returns Oracle type for oracle input`() {
+            assertThat(JdbcDatabaseType.from("oracle")).isEqualTo(JdbcDatabaseType.Oracle)
+            assertThat(JdbcDatabaseType.from("ORACLE")).isEqualTo(JdbcDatabaseType.Oracle)
+            assertThat(JdbcDatabaseType.from("Oracle")).isEqualTo(JdbcDatabaseType.Oracle)
         }
 
         @Test

--- a/namastack-outbox-jdbc/src/test/kotlin/io/namastack/outbox/schema/JdbcSchemaInitializationOracleIntegrationTest.kt
+++ b/namastack-outbox-jdbc/src/test/kotlin/io/namastack/outbox/schema/JdbcSchemaInitializationOracleIntegrationTest.kt
@@ -1,0 +1,34 @@
+package io.namastack.outbox.schema
+
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.OracleContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@Testcontainers
+class JdbcSchemaInitializationOracleIntegrationTest : AbstractJdbcSchemaInitializationTest() {
+    companion object {
+        private val log = LoggerFactory.getLogger(JdbcSchemaInitializationMySqlIntegrationTest::class.java)
+
+        @Container
+        @JvmStatic
+        val oracle: OracleContainer =
+            OracleContainer("gvenzl/oracle-xe:18-slim-faststart")
+                .withLogConsumer { log.info(it.utf8StringWithoutLineEnding) }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerProperties(registry: DynamicPropertyRegistry) {
+            if (!oracle.isRunning) {
+                oracle.start()
+            }
+
+            registry.add("spring.datasource.url") { oracle.jdbcUrl }
+            registry.add("spring.datasource.username") { oracle.username }
+            registry.add("spring.datasource.password") { oracle.password }
+            registry.add("spring.datasource.driver-class-name") { oracle.driverClassName }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces official support for Oracle Database, resolving #210.

Testing was performed using 18c within the CI/CD pipeline. Additionally, I’ve performed cross-version smoke tests against Oracle 19c and 21c to confirm consistent behavior.