### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/namastack/namastack-outbox/security/code-scanning/7](https://github.com/namastack/namastack-outbox/security/code-scanning/7)

Generally, the fix is to explicitly declare a `permissions:` block in the workflow or specific job, granting only the scopes required. For this workflow, the deploy job only needs to read the repository contents (for `actions/checkout`) and then use an external Vercel token; it does not need to write to the repo or interact with issues/PRs. Therefore, the best minimal fix is to set `permissions: contents: read` either at the root of the workflow (applying to all jobs) or at the `deploy` job level.

To avoid changing existing functionality and to keep the change tightly scoped, add a job-level `permissions:` block under `jobs.deploy`, at the same indentation level as `runs-on:`. Concretely, edit `.github/workflows/deploy-docs.yml` so that under `jobs: deploy:`, you insert:
```yaml
permissions:
  contents: read
```
No imports or additional definitions are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
