### PR TITLE
added rowmappers to the repositories

### DIFF
--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxInstanceRepository.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxInstanceRepository.kt
@@ -3,8 +3,10 @@ package io.namastack.outbox
 import io.namastack.outbox.instance.OutboxInstance
 import io.namastack.outbox.instance.OutboxInstanceRepository
 import io.namastack.outbox.instance.OutboxInstanceStatus
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.transaction.support.TransactionTemplate
+import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -27,6 +29,7 @@ internal open class JdbcOutboxInstanceRepository(
     private val tableNameResolver: JdbcTableNameResolver,
 ) : OutboxInstanceRepository {
     private val tableName = tableNameResolver.outboxInstance
+    private val rowMapper = JdbcOutboxInstanceEntityRowMapper()
 
     /**
      * Query to update an existing instance.
@@ -146,7 +149,7 @@ internal open class JdbcOutboxInstanceRepository(
         jdbcClient
             .sql(findByIdQuery)
             .param("instanceId", instanceId)
-            .query(JdbcOutboxInstanceEntity::class.java)
+            .query(rowMapper)
             .optional()
             .map { JdbcOutboxInstanceEntityMapper.map(it) }
             .orElse(null)
@@ -157,7 +160,7 @@ internal open class JdbcOutboxInstanceRepository(
     override fun findAll(): List<OutboxInstance> =
         jdbcClient
             .sql(findAllQuery)
-            .query(JdbcOutboxInstanceEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { JdbcOutboxInstanceEntityMapper.map(it) }
@@ -169,7 +172,7 @@ internal open class JdbcOutboxInstanceRepository(
         jdbcClient
             .sql(findByStatusQuery)
             .param("status", status.name)
-            .query(JdbcOutboxInstanceEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { JdbcOutboxInstanceEntityMapper.map(it) }
@@ -189,7 +192,7 @@ internal open class JdbcOutboxInstanceRepository(
             .sql(findStaleHeartbeatQueryTemplate)
             .param("cutoffTime", Timestamp.from(cutoffTime))
             .param("statuses", activeStatuses)
-            .query(JdbcOutboxInstanceEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { JdbcOutboxInstanceEntityMapper.map(it) }
@@ -286,5 +289,22 @@ internal open class JdbcOutboxInstanceRepository(
             .param("createdAt", Timestamp.from(entity.createdAt))
             .param("updatedAt", Timestamp.from(entity.updatedAt))
             .update()
+    }
+
+    private class JdbcOutboxInstanceEntityRowMapper : RowMapper<JdbcOutboxInstanceEntity> {
+        override fun mapRow(
+            rs: ResultSet,
+            rowNum: Int,
+        ): JdbcOutboxInstanceEntity =
+            JdbcOutboxInstanceEntity(
+                instanceId = rs.getString("instance_id"),
+                hostname = rs.getString("hostname"),
+                port = rs.getInt("port"),
+                status = OutboxInstanceStatus.valueOf(rs.getString("status")),
+                startedAt = rs.getTimestamp("started_at").toInstant(),
+                lastHeartbeat = rs.getTimestamp("last_heartbeat").toInstant(),
+                createdAt = rs.getTimestamp("created_at").toInstant(),
+                updatedAt = rs.getTimestamp("updated_at").toInstant(),
+            )
     }
 }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
@@ -189,15 +189,12 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
         override fun mapRow(
             rs: ResultSet,
             rowNum: Int,
-        ): JdbcOutboxPartitionAssignmentEntity {
-            val value = rs.getLong("version")
-            val version: Long? = if (rs.wasNull()) null else value
-            return JdbcOutboxPartitionAssignmentEntity(
+        ): JdbcOutboxPartitionAssignmentEntity =
+            JdbcOutboxPartitionAssignmentEntity(
                 partitionNumber = rs.getInt("partition_number"),
                 instanceId = rs.getString("instance_id"),
-                version = version,
+                version = rs.getLong("version"),
                 updatedAt = rs.getTimestamp("updated_at").toInstant(),
             )
-        }
     }
 }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
@@ -3,8 +3,10 @@ package io.namastack.outbox
 import io.namastack.outbox.partition.PartitionAssignment
 import io.namastack.outbox.partition.PartitionAssignmentRepository
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.transaction.support.TransactionTemplate
+import java.sql.ResultSet
 import java.sql.Timestamp
 
 /**
@@ -26,6 +28,7 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
     private val tableNameResolver: JdbcTableNameResolver,
 ) : PartitionAssignmentRepository {
     private val tableName = tableNameResolver.outboxPartitionAssignment
+    private val rowMapper = JdbcOutboxPartitionAssignmentEntityRowMapper()
 
     /**
      * Query to select all partition assignments ordered by partition number.
@@ -79,7 +82,7 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
     override fun findAll(): Set<PartitionAssignment> =
         jdbcClient
             .sql(findAllQuery)
-            .query(JdbcOutboxPartitionAssignmentEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { JdbcOutboxPartitionAssignmentEntityMapper.map(it) }
@@ -92,7 +95,7 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
         jdbcClient
             .sql(findByInstanceIdQuery)
             .param("instanceId", instanceId)
-            .query(JdbcOutboxPartitionAssignmentEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { JdbcOutboxPartitionAssignmentEntityMapper.map(it) }
@@ -180,5 +183,21 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
             .param("version", 0) // Initial version is 0
             .param("updatedAt", Timestamp.from(entity.updatedAt))
             .update()
+    }
+
+    private class JdbcOutboxPartitionAssignmentEntityRowMapper : RowMapper<JdbcOutboxPartitionAssignmentEntity> {
+        override fun mapRow(
+            rs: ResultSet,
+            rowNum: Int,
+        ): JdbcOutboxPartitionAssignmentEntity {
+            val value = rs.getLong("version")
+            val version: Long? = if (rs.wasNull()) null else value
+            return JdbcOutboxPartitionAssignmentEntity(
+                partitionNumber = rs.getInt("partition_number"),
+                instanceId = rs.getString("instance_id"),
+                version = version,
+                updatedAt = rs.getTimestamp("updated_at").toInstant(),
+            )
+        }
     }
 }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxRecordRepository.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxRecordRepository.kt
@@ -1,7 +1,9 @@
 package io.namastack.outbox
 
+import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.simple.JdbcClient
 import org.springframework.transaction.support.TransactionTemplate
+import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.Instant
 
@@ -29,6 +31,7 @@ internal open class JdbcOutboxRecordRepository(
 ) : OutboxRecordRepository,
     OutboxRecordStatusRepository {
     private val tableName = tableNameResolver.outboxRecord
+    private val rowMapper = JdbcOutboxRecordEntityRowMapper()
 
     /**
      * Query to update an existing outbox record.
@@ -195,7 +198,7 @@ internal open class JdbcOutboxRecordRepository(
             .sql(findByKeyAndStatusQuery)
             .param("recordKey", recordKey)
             .param("status", OutboxRecordStatus.NEW.name)
-            .query(JdbcOutboxRecordEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { entityMapper.map(it) }
@@ -344,8 +347,30 @@ internal open class JdbcOutboxRecordRepository(
         jdbcClient
             .sql(findByStatusQuery)
             .param("status", status.name)
-            .query(JdbcOutboxRecordEntity::class.java)
+            .query(rowMapper)
             .list()
             .filterNotNull()
             .map { entityMapper.map(it) }
+
+    private class JdbcOutboxRecordEntityRowMapper : RowMapper<JdbcOutboxRecordEntity> {
+        override fun mapRow(
+            rs: ResultSet,
+            rowNum: Int,
+        ): JdbcOutboxRecordEntity =
+            JdbcOutboxRecordEntity(
+                id = rs.getString("id"),
+                status = OutboxRecordStatus.valueOf(rs.getString("status")),
+                recordKey = rs.getString("record_key"),
+                recordType = rs.getString("record_type"),
+                payload = rs.getString("payload"),
+                context = rs.getString("context"),
+                partitionNo = rs.getInt("partition_no"),
+                createdAt = rs.getTimestamp("created_at").toInstant(),
+                completedAt = rs.getTimestamp("completed_at")?.toInstant(),
+                failureCount = rs.getInt("failure_count"),
+                failureReason = rs.getString("failure_reason"),
+                nextRetryAt = rs.getTimestamp("next_retry_at").toInstant(),
+                handlerId = rs.getString("handler_id"),
+            )
+    }
 }


### PR DESCRIPTION
Some Oracle JDBC drivers have limited support for 'getObject(int, Class)' with column type: java.time.Instant.
Added RowMapper<T> implementations to avoid the following:

> DEBUG org.springframework.jdbc.support.JdbcUtils JDBC driver has limited support for 'getObject(int, Class)' with column type: java.time.Instant

Should also perform slightly better since exception throwing during database fetches is avoided in these cases.
