### PR TITLE
GH-267 Add feature: time-based properties as java.time.Duration

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
@@ -63,14 +63,8 @@ class OutboxProcessingScheduler(
 
     private val log = LoggerFactory.getLogger(OutboxProcessingScheduler::class.java)
 
-    private val lifecycle =
-        SchedulerLifecycleStateMachine(
-            if (properties.processing.shutdownTimeoutSeconds != null) {
-                Duration.ofSeconds(properties.processing.shutdownTimeoutSeconds!!)
-            } else {
-                properties.processing.shutdownTimeout
-            },
-        )
+    private val lifecycle = SchedulerLifecycleStateMachine(properties.processing.shutdownTimeout)
+
     private var scheduledTask: ScheduledFuture<*>? = null
 
     /**

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
@@ -63,7 +63,7 @@ class OutboxProcessingScheduler(
 
     private val log = LoggerFactory.getLogger(OutboxProcessingScheduler::class.java)
 
-    private val lifecycle = SchedulerLifecycleStateMachine(properties.processing.shutdownTimeout)
+    private val lifecycle = SchedulerLifecycleStateMachine(properties.processing.effectiveShutdownTimeout)
 
     private var scheduledTask: ScheduledFuture<*>? = null
 
@@ -96,7 +96,7 @@ class OutboxProcessingScheduler(
      *
      * Automatically invoked during application shutdown. Cancels future scheduling and,
      * if a cycle is currently running, blocks until completion, timeout, or interruption
-     * (up to [OutboxProperties.Processing.shutdownTimeoutSeconds]).
+     * (up to [OutboxProperties.Processing.shutdownTimeout]).
      */
     override fun stop() {
         log.info("Initiating OutboxProcessingScheduler shutdown...")

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
@@ -12,6 +12,7 @@ import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.support.ScheduledMethodRunnable
 import java.lang.reflect.Method
 import java.time.Clock
+import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -62,7 +63,14 @@ class OutboxProcessingScheduler(
 
     private val log = LoggerFactory.getLogger(OutboxProcessingScheduler::class.java)
 
-    private val lifecycle = SchedulerLifecycleStateMachine(properties.processing.shutdownTimeoutSeconds)
+    private val lifecycle =
+        SchedulerLifecycleStateMachine(
+            if (properties.processing.shutdownTimeoutSeconds != null) {
+                Duration.ofSeconds(properties.processing.shutdownTimeoutSeconds!!)
+            } else {
+                properties.processing.shutdownTimeout
+            },
+        )
     private var scheduledTask: ScheduledFuture<*>? = null
 
     /**
@@ -207,10 +215,10 @@ class OutboxProcessingScheduler(
      * It coordinates job registration, processing execution, and graceful shutdown,
      * including waiting for an in-flight cycle to complete with a bounded timeout.
      *
-     * @param shutdownTimeoutSeconds Maximum time to wait for an active cycle during shutdown
+     * @param shutdownTimeout Maximum time to wait for an active cycle during shutdown
      */
     class SchedulerLifecycleStateMachine(
-        private val shutdownTimeoutSeconds: Long,
+        private val shutdownTimeout: Duration,
     ) {
         /**
          * Lifecycle states for scheduler registration and processing execution.
@@ -331,14 +339,14 @@ class OutboxProcessingScheduler(
             }
 
         private fun awaitProcessingComplete() {
-            log.debug("Waiting for processing cycle to complete (timeout={}s)", shutdownTimeoutSeconds)
+            log.debug("Waiting for processing cycle to complete (timeout={}ms)", shutdownTimeout.toMillis())
 
             try {
-                val completed = processingComplete.await(shutdownTimeoutSeconds, TimeUnit.SECONDS)
+                val completed = processingComplete.await(shutdownTimeout.toMillis(), TimeUnit.MILLISECONDS)
                 if (completed) {
                     log.trace("Processing cycle completed while shutting down")
                 } else {
-                    log.warn("Shutdown timeout reached after {}s; forcing shutdown", shutdownTimeoutSeconds)
+                    log.warn("Shutdown timeout reached after {}ms; forcing shutdown", shutdownTimeout.toMillis())
                 }
             } catch (ex: InterruptedException) {
                 Thread.currentThread().interrupt()

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
@@ -84,7 +84,7 @@ data class OutboxProperties(
      * @param executorCorePoolSize Core pool size for the processing executor
      * @param executorMaxPoolSize Maximum pool size for the processing executor
      * @param executorConcurrencyLimit Concurrency limit for the virtual thread executor (-1 for no limit)
-     * @param shutdownTimeoutSeconds Maximum time in seconnds to wait for processing to complete during shutdown (default: 30)
+     * @param shutdownTimeoutSeconds Maximum time in seconds to wait for processing to complete during shutdown (default: 30)
      * @param shutdownTimeoutValue Maximum time to wait for processing to complete during shutdown (default: 30s)
      */
     data class Processing(

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
@@ -1,6 +1,9 @@
 package io.namastack.outbox
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.convert.DurationUnit
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 /**
  * Configuration properties for Outbox functionality.
@@ -10,8 +13,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *
  * @param enabled Whether the outbox functionality is enabled. Defaults to true.
  *                Set to false to disable outbox auto-configuration entirely.
- * @param pollInterval Interval in milliseconds at which the outbox is polled (deprecated)
- * @param rebalanceInterval Interval in milliseconds at which partition rebalancing is performed (deprecated)
+ * @param pollInterval Interval at which the outbox is polled (deprecated)
+ * @param rebalanceInterval Interval at which partition rebalancing is performed (deprecated)
  * @param batchSize Maximum number of record keys to process in a single batch (deprecated)
  * @param polling Configuration for polling behavior
  * @param retry Configuration for retry mechanisms
@@ -26,9 +29,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class OutboxProperties(
     var enabled: Boolean = true,
     @Deprecated("Use polling.fixed.interval or polling.adaptive.minInterval/maxInterval instead")
-    var pollInterval: Long? = null,
+    var pollInterval: Duration? = null,
     @Deprecated("Use instance.rebalanceInterval instead")
-    var rebalanceInterval: Long? = null,
+    var rebalanceInterval: Duration? = null,
     @Deprecated("Use polling.batchsize instead")
     var batchSize: Int? = null,
     var polling: Polling = Polling(),
@@ -55,10 +58,10 @@ data class OutboxProperties(
     /**
      * Configuration for fixed polling strategy.
      *
-     * @param interval Fixed interval in milliseconds between polling cycles
+     * @param interval Fixed interval between polling cycles
      */
     data class FixedPolling(
-        var interval: Long = 2000,
+        var interval: Duration = Duration.ofSeconds(2),
     )
 
     /**
@@ -66,12 +69,12 @@ data class OutboxProperties(
      *
      * Adaptive polling adjusts the polling interval dynamically based on system activity.
      *
-     * @param minInterval Minimum interval in milliseconds between polling cycles
-     * @param maxInterval Maximum interval in milliseconds between polling cycles
+     * @param minInterval Minimum interval between polling cycles
+     * @param maxInterval Maximum interval between polling cycles
      */
     data class AdaptivePolling(
-        var minInterval: Long = 1000,
-        var maxInterval: Long = 8000,
+        var minInterval: Duration = Duration.ofSeconds(1),
+        var maxInterval: Duration = Duration.ofSeconds(8),
     )
 
     /**
@@ -83,7 +86,8 @@ data class OutboxProperties(
      * @param executorCorePoolSize Core pool size for the processing executor
      * @param executorMaxPoolSize Maximum pool size for the processing executor
      * @param executorConcurrencyLimit Concurrency limit for the virtual thread executor (-1 for no limit)
-     * @param shutdownTimeoutSeconds Maximum time in seconds to wait for processing to complete during shutdown (default: 30)
+     * @param shutdownTimeoutSeconds Maximum time in seconnds to wait for processing to complete during shutdown (default: 30)
+     * @param shutdownTimeout Maximum time to wait for processing to complete during shutdown (default: 30s)
      */
     data class Processing(
         var stopOnFirstFailure: Boolean = true,
@@ -93,7 +97,10 @@ data class OutboxProperties(
         var executorCorePoolSize: Int = 4,
         var executorMaxPoolSize: Int = 8,
         var executorConcurrencyLimit: Int = -1,
-        var shutdownTimeoutSeconds: Long = 30,
+        @Deprecated("Use shutdownTimeout instead")
+        var shutdownTimeoutSeconds: Long? = null,
+        @DurationUnit(ChronoUnit.SECONDS)
+        var shutdownTimeout: Duration = Duration.ofSeconds(30),
     )
 
     /**
@@ -102,14 +109,26 @@ data class OutboxProperties(
      * @param heartbeatIntervalSeconds Interval in seconds between heartbeats
      * @param staleInstanceTimeoutSeconds Timeout in seconds to consider an instance stale
      * @param gracefulShutdownTimeoutSeconds Optional propagation window (in seconds) after marking an instance
+     * @param heartbeatInterval Interval between heartbeats
+     * @param staleInstanceTimeout Timeout to consider an instance stale
+     * @param gracefulShutdownTimeout Optional propagation window after marking an instance
      *        as shutting down before removing it from the registry. Default: 0 (disabled).
-     * @param rebalanceInterval Interval in milliseconds at which partition rebalancing is performed
+     * @param rebalanceInterval Interval at which partition rebalancing is performed
      */
     data class Instance(
-        var heartbeatIntervalSeconds: Long = 5,
-        var staleInstanceTimeoutSeconds: Long = 30,
-        var gracefulShutdownTimeoutSeconds: Long = 0,
-        var rebalanceInterval: Long = 10000,
+        @Deprecated("Use heartbeatInterval instead")
+        var heartbeatIntervalSeconds: Long? = null,
+        @Deprecated("Use staleInstanceTimeout instead")
+        var staleInstanceTimeoutSeconds: Long? = null,
+        @Deprecated("Use gracefulShutdownTimeout instead")
+        var gracefulShutdownTimeoutSeconds: Long? = null,
+        @DurationUnit(ChronoUnit.SECONDS)
+        var heartbeatInterval: Duration = Duration.ofSeconds(5),
+        @DurationUnit(ChronoUnit.SECONDS)
+        var staleInstanceTimeout: Duration = Duration.ofSeconds(30),
+        @DurationUnit(ChronoUnit.SECONDS)
+        var gracefulShutdownTimeout: Duration = Duration.ofSeconds(0),
+        var rebalanceInterval: Duration = Duration.ofSeconds(10),
     )
 
     /**
@@ -134,7 +153,7 @@ data class OutboxProperties(
      * @param fixed Configuration for fixed delay retry
      * @param linear Configuration for linear backoff retry
      * @param exponential Configuration for exponential backoff retry
-     * @param jitter Maximum jitter in milliseconds to add or subtract from each delay (0 = no jitter)
+     * @param jitter Maximum jitter to add or subtract from each delay (0 = no jitter)
      * @param includeExceptions Fully qualified class names of exceptions to retry on
      * @param excludeExceptions Fully qualified class names of exceptions to exclude from retry
      */
@@ -144,43 +163,43 @@ data class OutboxProperties(
         var fixed: FixedRetry = FixedRetry(),
         var linear: LinearRetry = LinearRetry(),
         var exponential: ExponentialRetry = ExponentialRetry(),
-        var jitter: Long = 0,
+        var jitter: Duration = Duration.ofMillis(0),
         var includeExceptions: Set<String> = emptySet(),
         var excludeExceptions: Set<String> = emptySet(),
     ) {
         /**
          * Configuration for fixed delay retry policy.
          *
-         * @param delay Fixed delay in milliseconds between retries
+         * @param delay Fixed delay between retries
          */
         data class FixedRetry(
-            var delay: Long = 5000,
+            var delay: Duration = Duration.ofSeconds(5),
         )
 
         /**
          * Configuration for linear backoff retry policy.
          *
-         * @param initialDelay Initial delay in milliseconds
-         * @param increment Amount to add in milliseconds for each subsequent retry
-         * @param maxDelay Maximum delay in milliseconds
+         * @param initialDelay Initial delay
+         * @param increment Amount to add for each subsequent retry
+         * @param maxDelay Maximum delay
          */
         data class LinearRetry(
-            var initialDelay: Long = 2000,
-            var increment: Long = 2000,
-            var maxDelay: Long = 60000,
+            var initialDelay: Duration = Duration.ofSeconds(2),
+            var increment: Duration = Duration.ofSeconds(2),
+            var maxDelay: Duration = Duration.ofMinutes(1),
         )
 
         /**
          * Configuration for exponential backoff retry policy.
          *
-         * @param initialDelay Initial delay in milliseconds
+         * @param initialDelay Initial delay
          * @param multiplier Multiplier for exponential backoff
-         * @param maxDelay Maximum delay in milliseconds
+         * @param maxDelay Maximum delay
          */
         data class ExponentialRetry(
-            var initialDelay: Long = 2000,
+            var initialDelay: Duration = Duration.ofSeconds(2),
             var multiplier: Double = 2.0,
-            var maxDelay: Long = 60000,
+            var maxDelay: Duration = Duration.ofMinutes(1),
         )
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
@@ -1,9 +1,7 @@
 package io.namastack.outbox
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.convert.DurationUnit
 import java.time.Duration
-import java.time.temporal.ChronoUnit
 
 /**
  * Configuration properties for Outbox functionality.
@@ -87,7 +85,7 @@ data class OutboxProperties(
      * @param executorMaxPoolSize Maximum pool size for the processing executor
      * @param executorConcurrencyLimit Concurrency limit for the virtual thread executor (-1 for no limit)
      * @param shutdownTimeoutSeconds Maximum time in seconnds to wait for processing to complete during shutdown (default: 30)
-     * @param shutdownTimeout Maximum time to wait for processing to complete during shutdown (default: 30s)
+     * @param shutdownTimeoutValue Maximum time to wait for processing to complete during shutdown (default: 30s)
      */
     data class Processing(
         var stopOnFirstFailure: Boolean = true,
@@ -99,9 +97,14 @@ data class OutboxProperties(
         var executorConcurrencyLimit: Int = -1,
         @Deprecated("Use shutdownTimeout instead")
         var shutdownTimeoutSeconds: Long? = null,
-        @DurationUnit(ChronoUnit.SECONDS)
-        var shutdownTimeout: Duration = Duration.ofSeconds(30),
-    )
+        private var shutdownTimeoutValue: Duration = Duration.ofSeconds(30),
+    ) {
+        var shutdownTimeout: Duration
+            get() = shutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: shutdownTimeoutValue
+            set(value) {
+                shutdownTimeoutValue = value
+            }
+    }
 
     /**
      * Configuration for instance management and coordination.
@@ -109,9 +112,9 @@ data class OutboxProperties(
      * @param heartbeatIntervalSeconds Interval in seconds between heartbeats
      * @param staleInstanceTimeoutSeconds Timeout in seconds to consider an instance stale
      * @param gracefulShutdownTimeoutSeconds Optional propagation window (in seconds) after marking an instance
-     * @param heartbeatInterval Interval between heartbeats
-     * @param staleInstanceTimeout Timeout to consider an instance stale
-     * @param gracefulShutdownTimeout Optional propagation window after marking an instance
+     * @param heartbeatIntervalValue Interval between heartbeats
+     * @param staleInstanceTimeoutValue Timeout to consider an instance stale
+     * @param gracefulShutdownTimeoutValue Optional propagation window after marking an instance
      *        as shutting down before removing it from the registry. Default: 0 (disabled).
      * @param rebalanceInterval Interval at which partition rebalancing is performed
      */
@@ -122,14 +125,27 @@ data class OutboxProperties(
         var staleInstanceTimeoutSeconds: Long? = null,
         @Deprecated("Use gracefulShutdownTimeout instead")
         var gracefulShutdownTimeoutSeconds: Long? = null,
-        @DurationUnit(ChronoUnit.SECONDS)
-        var heartbeatInterval: Duration = Duration.ofSeconds(5),
-        @DurationUnit(ChronoUnit.SECONDS)
-        var staleInstanceTimeout: Duration = Duration.ofSeconds(30),
-        @DurationUnit(ChronoUnit.SECONDS)
-        var gracefulShutdownTimeout: Duration = Duration.ofSeconds(0),
+        private var heartbeatIntervalValue: Duration = Duration.ofSeconds(5),
+        private var staleInstanceTimeoutValue: Duration = Duration.ofSeconds(30),
+        private var gracefulShutdownTimeoutValue: Duration = Duration.ofSeconds(0),
         var rebalanceInterval: Duration = Duration.ofSeconds(10),
-    )
+    ) {
+        var heartbeatInterval: Duration
+            get() = heartbeatIntervalSeconds?.let(Duration::ofSeconds) ?: heartbeatIntervalValue
+            set(value) {
+                heartbeatIntervalValue = value
+            }
+        var staleInstanceTimeout: Duration
+            get() = staleInstanceTimeoutSeconds?.let(Duration::ofSeconds) ?: staleInstanceTimeoutValue
+            set(value) {
+                staleInstanceTimeoutValue = value
+            }
+        var gracefulShutdownTimeout: Duration
+            get() = gracefulShutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: gracefulShutdownTimeoutValue
+            set(value) {
+                gracefulShutdownTimeoutValue = value
+            }
+    }
 
     /**
      * Configuration for the custom application event multicaster.

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
@@ -85,7 +85,7 @@ data class OutboxProperties(
      * @param executorMaxPoolSize Maximum pool size for the processing executor
      * @param executorConcurrencyLimit Concurrency limit for the virtual thread executor (-1 for no limit)
      * @param shutdownTimeoutSeconds Maximum time in seconds to wait for processing to complete during shutdown (default: 30)
-     * @param shutdownTimeoutValue Maximum time to wait for processing to complete during shutdown (default: 30s)
+     * @param shutdownTimeout Maximum time to wait for processing to complete during shutdown (default: 30s)
      */
     data class Processing(
         var stopOnFirstFailure: Boolean = true,
@@ -97,13 +97,13 @@ data class OutboxProperties(
         var executorConcurrencyLimit: Int = -1,
         @Deprecated("Use shutdownTimeout instead")
         var shutdownTimeoutSeconds: Long? = null,
-        private var shutdownTimeoutValue: Duration = Duration.ofSeconds(30),
+        var shutdownTimeout: Duration = Duration.ofSeconds(30),
     ) {
-        var shutdownTimeout: Duration
-            get() = shutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: shutdownTimeoutValue
-            set(value) {
-                shutdownTimeoutValue = value
-            }
+        /**
+         * Returns the effective shutdown timeout, using the deprecated seconds property if set, otherwise the duration property.
+         */
+        val effectiveShutdownTimeout: Duration
+            get() = shutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: shutdownTimeout
     }
 
     /**
@@ -112,9 +112,9 @@ data class OutboxProperties(
      * @param heartbeatIntervalSeconds Interval in seconds between heartbeats
      * @param staleInstanceTimeoutSeconds Timeout in seconds to consider an instance stale
      * @param gracefulShutdownTimeoutSeconds Optional propagation window (in seconds) after marking an instance
-     * @param heartbeatIntervalValue Interval between heartbeats
-     * @param staleInstanceTimeoutValue Timeout to consider an instance stale
-     * @param gracefulShutdownTimeoutValue Optional propagation window after marking an instance
+     * @param heartbeatInterval Interval between heartbeats
+     * @param staleInstanceTimeout Timeout to consider an instance stale
+     * @param gracefulShutdownTimeout Optional propagation window after marking an instance
      *        as shutting down before removing it from the registry. Default: 0 (disabled).
      * @param rebalanceInterval Interval at which partition rebalancing is performed
      */
@@ -125,26 +125,28 @@ data class OutboxProperties(
         var staleInstanceTimeoutSeconds: Long? = null,
         @Deprecated("Use gracefulShutdownTimeout instead")
         var gracefulShutdownTimeoutSeconds: Long? = null,
-        private var heartbeatIntervalValue: Duration = Duration.ofSeconds(5),
-        private var staleInstanceTimeoutValue: Duration = Duration.ofSeconds(30),
-        private var gracefulShutdownTimeoutValue: Duration = Duration.ofSeconds(0),
+        var heartbeatInterval: Duration = Duration.ofSeconds(5),
+        var staleInstanceTimeout: Duration = Duration.ofSeconds(30),
+        var gracefulShutdownTimeout: Duration = Duration.ofSeconds(0),
         var rebalanceInterval: Duration = Duration.ofSeconds(10),
     ) {
-        var heartbeatInterval: Duration
-            get() = heartbeatIntervalSeconds?.let(Duration::ofSeconds) ?: heartbeatIntervalValue
-            set(value) {
-                heartbeatIntervalValue = value
-            }
-        var staleInstanceTimeout: Duration
-            get() = staleInstanceTimeoutSeconds?.let(Duration::ofSeconds) ?: staleInstanceTimeoutValue
-            set(value) {
-                staleInstanceTimeoutValue = value
-            }
-        var gracefulShutdownTimeout: Duration
-            get() = gracefulShutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: gracefulShutdownTimeoutValue
-            set(value) {
-                gracefulShutdownTimeoutValue = value
-            }
+        /**
+         * Returns the effective heartbeat interval, using the deprecated seconds property if set, otherwise the duration property.
+         */
+        val effectiveHeartbeatInterval: Duration
+            get() = heartbeatIntervalSeconds?.let(Duration::ofSeconds) ?: heartbeatInterval
+
+        /**
+         * Returns the effective stale instance timeout, using the deprecated seconds property if set, otherwise the duration property.
+         */
+        val effectiveStaleInstanceTimeout: Duration
+            get() = staleInstanceTimeoutSeconds?.let(Duration::ofSeconds) ?: staleInstanceTimeout
+
+        /**
+         * Returns the effective graceful shutdown timeout, using the deprecated seconds property if set, otherwise the duration property.
+         */
+        val effectiveGracefulShutdownTimeout: Duration
+            get() = gracefulShutdownTimeoutSeconds?.let(Duration::ofSeconds) ?: gracefulShutdownTimeout
     }
 
     /**

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox.config
 
+import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.Outbox
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.OutboxRecordRepository
@@ -20,6 +21,7 @@ import io.namastack.outbox.retry.OutboxRetryPolicy
 import io.namastack.outbox.retry.OutboxRetryPolicyFactory
 import io.namastack.outbox.retry.OutboxRetryPolicyRegistry
 import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage
@@ -70,7 +72,15 @@ class OutboxCoreInfrastructureAutoConfiguration {
         properties: OutboxProperties,
         clock: Clock,
         taskScheduler: TaskScheduler,
-    ): OutboxInstanceRegistry = OutboxInstanceRegistry(instanceRepository, properties, clock, taskScheduler)
+        observationRegistry: ObjectProvider<ObservationRegistry>,
+    ): OutboxInstanceRegistry =
+        OutboxInstanceRegistry(
+            instanceRepository,
+            properties,
+            clock,
+            taskScheduler,
+            { observationRegistry.getIfAvailable { ObservationRegistry.NOOP } },
+        )
 
     @Bean
     @ConditionalOnMissingBean

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Role
+import org.springframework.scheduling.TaskScheduler
 import java.time.Clock
 
 @AutoConfiguration
@@ -68,7 +69,8 @@ class OutboxCoreInfrastructureAutoConfiguration {
         instanceRepository: OutboxInstanceRepository,
         properties: OutboxProperties,
         clock: Clock,
-    ): OutboxInstanceRegistry = OutboxInstanceRegistry(instanceRepository, properties, clock)
+        taskScheduler: TaskScheduler,
+    ): OutboxInstanceRegistry = OutboxInstanceRegistry(instanceRepository, properties, clock, taskScheduler)
 
     @Bean
     @ConditionalOnMissingBean

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -2,6 +2,7 @@ package io.namastack.outbox.config
 
 import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.Outbox
+import io.namastack.outbox.OutboxProcessingScheduler
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.OutboxRecordRepository
 import io.namastack.outbox.OutboxService
@@ -71,16 +72,18 @@ class OutboxCoreInfrastructureAutoConfiguration {
         instanceRepository: OutboxInstanceRepository,
         properties: OutboxProperties,
         clock: Clock,
-        taskScheduler: TaskScheduler,
+        beanFactory: BeanFactory,
         observationRegistry: ObjectProvider<ObservationRegistry>,
-    ): OutboxInstanceRegistry =
-        OutboxInstanceRegistry(
+    ): OutboxInstanceRegistry {
+        val taskScheduler = beanFactory.getBean(OutboxProcessingScheduler.SCHEDULER_NAME) as TaskScheduler
+        return OutboxInstanceRegistry(
             instanceRepository,
             properties,
             clock,
             taskScheduler,
             { observationRegistry.getIfAvailable { ObservationRegistry.NOOP } },
         )
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
@@ -3,12 +3,12 @@ package io.namastack.outbox.instance
 import io.namastack.outbox.OpenForProxy
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.instance.OutboxInstanceStatus.ACTIVE
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.context.SmartLifecycle
-import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.scheduling.TaskScheduler
 import java.net.InetAddress
 import java.time.Clock
-import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param instanceRepository Repository for persisting instance data
  * @param properties Configuration properties for outbox instance management
  * @param clock Clock for consistent time-based operations
+ * @param taskScheduler TaskScheduler used to schedule the heartbeat
  *
  * @author Roland Beisel
  * @since 0.2.0
@@ -41,22 +42,14 @@ class OutboxInstanceRegistry(
     private val instanceRepository: OutboxInstanceRepository,
     private val properties: OutboxProperties,
     private val clock: Clock,
+    private val taskScheduler: TaskScheduler,
     private val currentInstanceId: String = UUID.randomUUID().toString(),
 ) : SmartLifecycle {
     private val log = LoggerFactory.getLogger(OutboxInstanceRegistry::class.java)
 
-    private val staleInstanceTimeout =
-        if (properties.instance.staleInstanceTimeoutSeconds != null) {
-            Duration.ofSeconds(properties.instance.staleInstanceTimeoutSeconds!!)
-        } else {
-            properties.instance.staleInstanceTimeout
-        }
-    private val gracefulShutdownTimeout =
-        if (properties.instance.gracefulShutdownTimeoutSeconds != null) {
-            Duration.ofSeconds(properties.instance.gracefulShutdownTimeoutSeconds!!)
-        } else {
-            properties.instance.gracefulShutdownTimeout
-        }
+    private val staleInstanceTimeout = properties.instance.staleInstanceTimeout
+
+    private val gracefulShutdownTimeout = properties.instance.gracefulShutdownTimeout
 
     private val running = AtomicBoolean(false)
 
@@ -151,15 +144,17 @@ class OutboxInstanceRegistry(
         }
     }
 
+    @PostConstruct
+    fun scheduleHeartbeat() {
+        val rate = properties.instance.heartbeatInterval
+        taskScheduler.scheduleAtFixedRate({ performHeartbeatAndCleanup() }, rate)
+    }
+
     /**
      * Periodic heartbeat + stale cleanup trigger.
      * Combines update & pruning to reduce scheduling overhead.
      */
-    @Scheduled(
-        fixedRateString = $$"${namastack.outbox.instance.heartbeat-interval:5000}",
-        scheduler = "outboxHeartbeatScheduler",
-    )
-    fun performHeartbeatAndCleanup() {
+    internal fun performHeartbeatAndCleanup() {
         try {
             sendHeartbeat()
             cleanupStaleInstances()

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
@@ -58,9 +58,8 @@ class OutboxInstanceRegistry(
 
     private val log = LoggerFactory.getLogger(OutboxInstanceRegistry::class.java)
 
-    private val staleInstanceTimeout = properties.instance.staleInstanceTimeout
-
-    private val gracefulShutdownTimeout = properties.instance.gracefulShutdownTimeout
+    private val staleInstanceTimeout = properties.instance.effectiveStaleInstanceTimeout
+    private val gracefulShutdownTimeout = properties.instance.effectiveGracefulShutdownTimeout
 
     private val running = AtomicBoolean(false)
     private var scheduledHeartbeat: ScheduledFuture<*>? = null
@@ -80,7 +79,7 @@ class OutboxInstanceRegistry(
     override fun start() {
         registerInstance()
         running.set(true)
-        val rate = properties.instance.heartbeatInterval
+        val rate = properties.instance.effectiveHeartbeatInterval
         val runnable = ScheduledMethodRunnable(this, SCHEDULE_METHOD, SCHEDULER_NAME, observationRegistry)
         scheduledHeartbeat = taskScheduler.scheduleAtFixedRate(runnable, rate)
     }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
@@ -13,6 +13,7 @@ import java.net.InetAddress
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -62,6 +63,7 @@ class OutboxInstanceRegistry(
     private val gracefulShutdownTimeout = properties.instance.gracefulShutdownTimeout
 
     private val running = AtomicBoolean(false)
+    private var scheduledHeartbeat: ScheduledFuture<*>? = null
 
     override fun getPhase(): Int = 0
 
@@ -79,9 +81,8 @@ class OutboxInstanceRegistry(
         registerInstance()
         running.set(true)
         val rate = properties.instance.heartbeatInterval
-        taskScheduler.scheduleAtFixedRate({ performHeartbeatAndCleanup() }, rate)
         val runnable = ScheduledMethodRunnable(this, SCHEDULE_METHOD, SCHEDULER_NAME, observationRegistry)
-        taskScheduler.scheduleAtFixedRate(runnable, rate)
+        scheduledHeartbeat = taskScheduler.scheduleAtFixedRate(runnable, rate)
     }
 
     /**
@@ -94,6 +95,7 @@ class OutboxInstanceRegistry(
     override fun stop() {
         try {
             log.info("Initiating graceful shutdown for instance {}", currentInstanceId)
+            scheduledHeartbeat?.cancel(false)
 
             instanceRepository.updateStatus(
                 currentInstanceId,
@@ -125,7 +127,7 @@ class OutboxInstanceRegistry(
     /** True if the given instance currently has status ACTIVE. */
     fun isInstanceActive(instanceId: String): Boolean = instanceRepository.findById(instanceId)?.status == ACTIVE
 
-    /** Number of ACTIVE instances. */
+    /** Number of active instances. */
     fun getActiveInstanceCount(): Long = instanceRepository.countByStatus(ACTIVE)
 
     /**

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
@@ -1,12 +1,14 @@
 package io.namastack.outbox.instance
 
+import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.OpenForProxy
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.instance.OutboxInstanceStatus.ACTIVE
-import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.context.SmartLifecycle
 import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.support.ScheduledMethodRunnable
+import java.lang.reflect.Method
 import java.net.InetAddress
 import java.time.Clock
 import java.time.Instant
@@ -43,8 +45,16 @@ class OutboxInstanceRegistry(
     private val properties: OutboxProperties,
     private val clock: Clock,
     private val taskScheduler: TaskScheduler,
+    private val observationRegistry: () -> ObservationRegistry,
     private val currentInstanceId: String = UUID.randomUUID().toString(),
 ) : SmartLifecycle {
+    companion object {
+        const val SCHEDULER_NAME: String = "outboxHeartbeatScheduler"
+
+        private val SCHEDULE_METHOD_NAME: String = (OutboxInstanceRegistry::performHeartbeatAndCleanup).name
+        private val SCHEDULE_METHOD: Method = OutboxInstanceRegistry::class.java.getMethod(SCHEDULE_METHOD_NAME)
+    }
+
     private val log = LoggerFactory.getLogger(OutboxInstanceRegistry::class.java)
 
     private val staleInstanceTimeout = properties.instance.staleInstanceTimeout
@@ -68,6 +78,10 @@ class OutboxInstanceRegistry(
     override fun start() {
         registerInstance()
         running.set(true)
+        val rate = properties.instance.heartbeatInterval
+        taskScheduler.scheduleAtFixedRate({ performHeartbeatAndCleanup() }, rate)
+        val runnable = ScheduledMethodRunnable(this, SCHEDULE_METHOD, SCHEDULER_NAME, observationRegistry)
+        taskScheduler.scheduleAtFixedRate(runnable, rate)
     }
 
     /**
@@ -144,17 +158,11 @@ class OutboxInstanceRegistry(
         }
     }
 
-    @PostConstruct
-    fun scheduleHeartbeat() {
-        val rate = properties.instance.heartbeatInterval
-        taskScheduler.scheduleAtFixedRate({ performHeartbeatAndCleanup() }, rate)
-    }
-
     /**
      * Periodic heartbeat + stale cleanup trigger.
      * Combines update & pruning to reduce scheduling overhead.
      */
-    internal fun performHeartbeatAndCleanup() {
+    fun performHeartbeatAndCleanup() {
         try {
             sendHeartbeat()
             cleanupStaleInstances()

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/instance/OutboxInstanceRegistry.kt
@@ -45,8 +45,18 @@ class OutboxInstanceRegistry(
 ) : SmartLifecycle {
     private val log = LoggerFactory.getLogger(OutboxInstanceRegistry::class.java)
 
-    private val staleInstanceTimeout = Duration.ofSeconds(properties.instance.staleInstanceTimeoutSeconds)
-    private val gracefulShutdownTimeout = Duration.ofSeconds(properties.instance.gracefulShutdownTimeoutSeconds)
+    private val staleInstanceTimeout =
+        if (properties.instance.staleInstanceTimeoutSeconds != null) {
+            Duration.ofSeconds(properties.instance.staleInstanceTimeoutSeconds!!)
+        } else {
+            properties.instance.staleInstanceTimeout
+        }
+    private val gracefulShutdownTimeout =
+        if (properties.instance.gracefulShutdownTimeoutSeconds != null) {
+            Duration.ofSeconds(properties.instance.gracefulShutdownTimeoutSeconds!!)
+        } else {
+            properties.instance.gracefulShutdownTimeout
+        }
 
     private val running = AtomicBoolean(false)
 
@@ -146,7 +156,7 @@ class OutboxInstanceRegistry(
      * Combines update & pruning to reduce scheduling overhead.
      */
     @Scheduled(
-        fixedRateString = $$"${namastack.outbox.instance.heartbeat-interval-seconds:5}000",
+        fixedRateString = $$"${namastack.outbox.instance.heartbeat-interval:5000}",
         scheduler = "outboxHeartbeatScheduler",
     )
     fun performHeartbeatAndCleanup() {

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyFactory.kt
@@ -1,7 +1,6 @@
 package io.namastack.outbox.retry
 
 import io.namastack.outbox.OutboxProperties
-import java.time.Duration
 
 /**
  * Factory for creating retry policy instances based on configuration.
@@ -68,26 +67,26 @@ internal object OutboxRetryPolicyFactory {
             "fixed" -> {
                 builder
                     .fixedBackOff(
-                        delay = Duration.ofMillis(retryProperties.fixed.delay),
-                    ).jitter(jitter = Duration.ofMillis(retryProperties.jitter))
+                        delay = retryProperties.fixed.delay,
+                    ).jitter(jitter = retryProperties.jitter)
             }
 
             "linear" -> {
                 builder
                     .linearBackoff(
-                        initialDelay = Duration.ofMillis(retryProperties.linear.initialDelay),
-                        increment = Duration.ofMillis(retryProperties.linear.increment),
-                        maxDelay = Duration.ofMillis(retryProperties.linear.maxDelay),
-                    ).jitter(jitter = Duration.ofMillis(retryProperties.jitter))
+                        initialDelay = retryProperties.linear.initialDelay,
+                        increment = retryProperties.linear.increment,
+                        maxDelay = retryProperties.linear.maxDelay,
+                    ).jitter(jitter = retryProperties.jitter)
             }
 
             "exponential" -> {
                 builder
                     .exponentialBackoff(
-                        initialDelay = Duration.ofMillis(retryProperties.exponential.initialDelay),
+                        initialDelay = retryProperties.exponential.initialDelay,
                         multiplier = retryProperties.exponential.multiplier,
-                        maxDelay = Duration.ofMillis(retryProperties.exponential.maxDelay),
-                    ).jitter(jitter = Duration.ofMillis(retryProperties.jitter))
+                        maxDelay = retryProperties.exponential.maxDelay,
+                    ).jitter(jitter = retryProperties.jitter)
             }
 
             else -> {

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/trigger/OutboxPollingTriggerFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/trigger/OutboxPollingTriggerFactory.kt
@@ -2,7 +2,6 @@ package io.namastack.outbox.trigger
 
 import io.namastack.outbox.OutboxProperties
 import java.time.Clock
-import java.time.Duration
 
 /**
  * Factory for creating [OutboxPollingTrigger] instances based on configuration properties.
@@ -43,15 +42,15 @@ internal object OutboxPollingTriggerFactory {
         return when (name.lowercase()) {
             "fixed" -> {
                 FixedPollingTrigger(
-                    delay = Duration.ofMillis(properties.pollInterval ?: properties.polling.fixed.interval),
+                    delay = properties.pollInterval ?: properties.polling.fixed.interval,
                     clock = clock,
                 )
             }
 
             "adaptive" -> {
                 AdaptivePollingTrigger(
-                    minDelay = Duration.ofMillis(properties.polling.adaptive.minInterval),
-                    maxDelay = Duration.ofMillis(properties.polling.adaptive.maxInterval),
+                    minDelay = properties.polling.adaptive.minInterval,
+                    maxDelay = properties.polling.adaptive.maxInterval,
                     batchSize = properties.batchSize ?: properties.polling.batchSize,
                     clock = clock,
                 )

--- a/namastack-outbox-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/namastack-outbox-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -76,10 +76,10 @@
     },
     {
       "name": "namastack.outbox.poll-interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties",
-      "defaultValue": 2000,
-      "description": "Interval in milliseconds at which the outbox is polled",
+      "defaultValue": "2s",
+      "description": "Interval at which the outbox is polled",
       "deprecation": {
         "reason": "Use polling.fixed.interval or polling.adaptive.min-interval/max-interval instead",
         "replacement": "namastack.outbox.polling.fixed.interval"
@@ -98,10 +98,10 @@
     },
     {
       "name": "namastack.outbox.rebalance-interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties",
-      "defaultValue": 10000,
-      "description": "Interval in milliseconds at which partition rebalancing is triggered",
+      "defaultValue": "10s",
+      "description": "Interval at which partition rebalancing is triggered",
       "deprecation": {
         "reason": "Use instance.rebalanceInterval instead",
         "replacement": "namastack.outbox.instance.rebalance-interval"
@@ -123,24 +123,24 @@
     },
     {
       "name": "namastack.outbox.polling.fixed.interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Polling$FixedPolling",
-      "defaultValue": 2000,
-      "description": "Fixed interval in milliseconds between polling cycles"
+      "defaultValue": "2s",
+      "description": "Fixed interval between polling cycles"
     },
     {
       "name": "namastack.outbox.polling.adaptive.min-interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Polling$AdaptivePolling",
-      "defaultValue": 1000,
-      "description": "Minimum interval in milliseconds between polling cycles for adaptive polling"
+      "defaultValue": "1s",
+      "description": "Minimum interval between polling cycles for adaptive polling"
     },
     {
       "name": "namastack.outbox.polling.adaptive.max-interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Polling$AdaptivePolling",
-      "defaultValue": 8000,
-      "description": "Maximum interval in milliseconds between polling cycles for adaptive polling"
+      "defaultValue": "8s",
+      "description": "Maximum interval between polling cycles for adaptive polling"
     },
     {
       "name": "namastack.outbox.retry.max-retries",
@@ -158,45 +158,45 @@
     },
     {
       "name": "namastack.outbox.retry.fixed.delay",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$FixedRetry",
-      "defaultValue": 5000,
-      "description": "Fixed delay in milliseconds between retry attempts for fixed delay retry policy"
+      "defaultValue": "5s",
+      "description": "Fixed delay between retry attempts for fixed delay retry policy"
     },
     {
       "name": "namastack.outbox.retry.linear.initial-delay",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$LinearRetry",
-      "defaultValue": 2000,
-      "description": "Initial delay in milliseconds for linear backoff retry policy"
+      "defaultValue": "2s",
+      "description": "Initial delay for linear backoff retry policy"
     },
     {
       "name": "namastack.outbox.retry.linear.increment",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$LinearRetry",
-      "defaultValue": 2000,
-      "description": "Amount in milliseconds to add for each subsequent retry"
+      "defaultValue": "2s",
+      "description": "Amount to add for each subsequent retry"
     },
     {
       "name": "namastack.outbox.retry.linear.max-delay",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$LinearRetry",
-      "defaultValue": 60000,
-      "description": "Maximum delay in milliseconds for linear backoff retry policy"
+      "defaultValue": "1m",
+      "description": "Maximum delay for linear backoff retry policy"
     },
     {
       "name": "namastack.outbox.retry.exponential.initial-delay",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$ExponentialRetry",
-      "defaultValue": 2000,
-      "description": "Initial delay in milliseconds for exponential backoff retry policy"
+      "defaultValue": "2s",
+      "description": "Initial delay for exponential backoff retry policy"
     },
     {
       "name": "namastack.outbox.retry.exponential.max-delay",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry$ExponentialRetry",
-      "defaultValue": 60000,
-      "description": "Maximum delay in milliseconds for exponential backoff retry policy"
+      "defaultValue": "1m",
+      "description": "Maximum delay for exponential backoff retry policy"
     },
     {
       "name": "namastack.outbox.retry.exponential.multiplier",
@@ -207,10 +207,10 @@
     },
     {
       "name": "namastack.outbox.retry.jitter",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Retry",
-      "defaultValue": 0,
-      "description": "Maximum jitter in milliseconds to add or subtract from each delay. A random value between -jitter and +jitter is applied. Default: 0 (no jitter)."
+      "defaultValue": "0ms",
+      "description": "Maximum jitter to add or subtract from each delay. A random value between -jitter and +jitter is applied. Default: 0 (no jitter)."
     },
     {
       "name": "namastack.outbox.retry.include-exceptions",
@@ -271,39 +271,83 @@
       "description": "Concurrency limit for the SimpleAsyncTaskExecutor used for parallel processing of record keys when virtual threads are enabled. Default: -1 (no limit)."
     },
     {
-      "name": "namastack.outbox.processing.shutdown-timeout-seconds",
+      "name": "namastack.outbox.processing.shutdown-timeout-secods",
       "type": "java.lang.Long",
       "sourceType": "io.namastack.outbox.OutboxProperties$Processing",
       "defaultValue": 30,
-      "description": "Maximum time in seconds to wait for the current processing cycle to complete during application shutdown. If the timeout is exceeded, shutdown proceeds without waiting for completion. Default: 30."
+      "description": "Maximum time in seconds to wait for the current processing cycle to complete during application shutdown. If the timeout is exceeded, shutdown proceeds without waiting for completion. Default: 30.",
+      "deprecation": {
+        "reason": "Use shutdown-timeout instead",
+        "replacement": "namastack.outbox.processing.shutdown-timeout"
+      }
+    },
+    {
+      "name": "namastack.outbox.processing.shutdown-timeout",
+      "type": "java.time.Duration",
+      "sourceType": "io.namastack.outbox.OutboxProperties$Processing",
+      "defaultValue": "30s",
+      "description": "Maximum time to wait for the current processing cycle to complete during application shutdown. If the timeout is exceeded, shutdown proceeds without waiting for completion. Default: 30s."
     },
     {
       "name": "namastack.outbox.instance.graceful-shutdown-timeout-seconds",
       "type": "java.lang.Long",
       "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
       "defaultValue": 0,
-      "description": "Timeout in seconds for graceful shutdown of outbox processing instances"
+      "description": "Timeout in seconds for graceful shutdown of outbox processing instances",
+      "deprecation": {
+        "reason": "Use graceful-shutdown-timeout instead",
+        "replacement": "namastack.outbox.instance.graceful-shutdown-timeout"
+      }
+    },
+    {
+      "name": "namastack.outbox.instance.graceful-shutdown-timeout",
+      "type": "java.time.Duration",
+      "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
+      "defaultValue": "0s",
+      "description": "Timeout for graceful shutdown of outbox processing instances"
     },
     {
       "name": "namastack.outbox.instance.stale-instance-timeout-seconds",
       "type": "java.lang.Long",
       "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
       "defaultValue": 30,
-      "description": "Timeout in seconds to consider an instance stale and remove it from active instances"
+      "description": "Timeout in seconds to consider an instance stale and remove it from active instances",
+      "deprecation": {
+        "reason": "Use stale-instance-timeout instead",
+        "replacement": "namastack.outbox.instance.stale-instance-timeout"
+      }
+    },
+    {
+      "name": "namastack.outbox.instance.stale-instance-timeout",
+      "type": "java.time.Duration",
+      "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
+      "defaultValue": "30s",
+      "description": "Timeout to consider an instance stale and remove it from active instances"
     },
     {
       "name": "namastack.outbox.instance.heartbeat-interval-seconds",
       "type": "java.lang.Long",
       "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
       "defaultValue": 5,
-      "description": "Interval in seconds between instance heartbeats to indicate the instance is still active"
+      "description": "Interval in seconds between instance heartbeats to indicate the instance is still active",
+      "deprecation": {
+        "reason": "Use heartbeat-interval instead",
+        "replacement": "namastack.outbox.instance.heartbeat-interval"
+      }
+    },
+    {
+      "name": "namastack.outbox.instance.heartbeat-interval",
+      "type": "java.time.Duration",
+      "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
+      "defaultValue": "5s",
+      "description": "Interval between instance heartbeats to indicate the instance is still active"
     },
     {
       "name": "namastack.outbox.instance.rebalance-interval",
-      "type": "java.lang.Long",
+      "type": "java.time.Duration",
       "sourceType": "io.namastack.outbox.OutboxProperties$Instance",
-      "defaultValue": 10000,
-      "description": "Interval in milliseconds at which partition rebalancing is performed"
+      "defaultValue": "10s",
+      "description": "Interval at which partition rebalancing is performed"
     },
     {
       "name": "namastack.outbox.multicaster.enabled",

--- a/namastack-outbox-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/namastack-outbox-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -271,7 +271,7 @@
       "description": "Concurrency limit for the SimpleAsyncTaskExecutor used for parallel processing of record keys when virtual threads are enabled. Default: -1 (no limit)."
     },
     {
-      "name": "namastack.outbox.processing.shutdown-timeout-secods",
+      "name": "namastack.outbox.processing.shutdown-timeout-seconds",
       "type": "java.lang.Long",
       "sourceType": "io.namastack.outbox.OutboxProperties$Processing",
       "defaultValue": 30,

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
@@ -201,9 +201,9 @@ class OutboxCoreAutoConfigurationTest {
                     assertThat(context).hasNotFailed()
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
                     val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
-                    assertThat(properties.instance.staleInstanceTimeout.seconds).isEqualTo(60)
-                    assertThat(properties.instance.heartbeatInterval.toMinutes()).isEqualTo(60)
-                    assertThat(properties.instance.gracefulShutdownTimeout.toMillis()).isEqualTo(500)
+                    assertThat(properties.instance.effectiveStaleInstanceTimeout.seconds).isEqualTo(60)
+                    assertThat(properties.instance.effectiveHeartbeatInterval.toMinutes()).isEqualTo(60)
+                    assertThat(properties.instance.effectiveGracefulShutdownTimeout.toMillis()).isEqualTo(500)
                 }
         }
 
@@ -219,9 +219,9 @@ class OutboxCoreAutoConfigurationTest {
                     assertThat(context).hasNotFailed()
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
                     val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
-                    assertThat(properties.instance.staleInstanceTimeout.seconds).isEqualTo(1)
-                    assertThat(properties.instance.heartbeatInterval.seconds).isEqualTo(1)
-                    assertThat(properties.instance.gracefulShutdownTimeout.seconds).isEqualTo(1)
+                    assertThat(properties.instance.effectiveStaleInstanceTimeout.seconds).isEqualTo(1)
+                    assertThat(properties.instance.effectiveHeartbeatInterval.seconds).isEqualTo(1)
+                    assertThat(properties.instance.effectiveGracefulShutdownTimeout.seconds).isEqualTo(1)
                 }
         }
 
@@ -235,7 +235,7 @@ class OutboxCoreAutoConfigurationTest {
                     assertThat(context).hasNotFailed()
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
                     val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
-                    assertThat(properties.processing.shutdownTimeout.toMillis()).isEqualTo(500)
+                    assertThat(properties.processing.effectiveShutdownTimeout.toMillis()).isEqualTo(500)
                 }
         }
 
@@ -249,7 +249,7 @@ class OutboxCoreAutoConfigurationTest {
                     assertThat(context).hasNotFailed()
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
                     val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
-                    assertThat(properties.processing.shutdownTimeout.seconds).isEqualTo(1)
+                    assertThat(properties.processing.effectiveShutdownTimeout.seconds).isEqualTo(1)
                 }
         }
     }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
@@ -208,7 +208,7 @@ class OutboxCoreAutoConfigurationTest {
         }
 
         @Test
-        fun `applies deprectaed instance configuration properties`() {
+        fun `applies deprecated instance configuration properties`() {
             contextRunner
                 .withUserConfiguration(MinimalTestConfig::class.java)
                 .withPropertyValues(
@@ -222,6 +222,34 @@ class OutboxCoreAutoConfigurationTest {
                     assertThat(properties.instance.staleInstanceTimeout.seconds).isEqualTo(1)
                     assertThat(properties.instance.heartbeatInterval.seconds).isEqualTo(1)
                     assertThat(properties.instance.gracefulShutdownTimeout.seconds).isEqualTo(1)
+                }
+        }
+
+        @Test
+        fun `applies shutdown timeout configuration property`() {
+            contextRunner
+                .withUserConfiguration(MinimalTestConfig::class.java)
+                .withPropertyValues(
+                    "namastack.outbox.processing.shutdown-timeout=500ms",
+                ).run { context ->
+                    assertThat(context).hasNotFailed()
+                    assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
+                    val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
+                    assertThat(properties.processing.shutdownTimeout.toMillis()).isEqualTo(500)
+                }
+        }
+
+        @Test
+        fun `applies deprecated shutdown timeout configuration property`() {
+            contextRunner
+                .withUserConfiguration(MinimalTestConfig::class.java)
+                .withPropertyValues(
+                    "namastack.outbox.processing.shutdown-timeout-seconds=1",
+                ).run { context ->
+                    assertThat(context).hasNotFailed()
+                    assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
+                    val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
+                    assertThat(properties.processing.shutdownTimeout.seconds).isEqualTo(1)
                 }
         }
     }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
@@ -194,11 +194,34 @@ class OutboxCoreAutoConfigurationTest {
             contextRunner
                 .withUserConfiguration(MinimalTestConfig::class.java)
                 .withPropertyValues(
-                    "namastack.outbox.instance.stale-instance-timeout-seconds=1",
-                    "namastack.outbox.instance.heartbeat-interval-seconds=1",
+                    "namastack.outbox.instance.stale-instance-timeout=1m",
+                    "namastack.outbox.instance.heartbeat-interval=1h",
+                    "namastack.outbox.instance.graceful-shutdown-timeout=500ms",
                 ).run { context ->
                     assertThat(context).hasNotFailed()
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
+                    val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
+                    assertThat(properties.instance.staleInstanceTimeout.seconds).isEqualTo(60)
+                    assertThat(properties.instance.heartbeatInterval.toMinutes()).isEqualTo(60)
+                    assertThat(properties.instance.gracefulShutdownTimeout.toMillis()).isEqualTo(500)
+                }
+        }
+
+        @Test
+        fun `applies deprectaed instance configuration properties`() {
+            contextRunner
+                .withUserConfiguration(MinimalTestConfig::class.java)
+                .withPropertyValues(
+                    "namastack.outbox.instance.stale-instance-timeout-seconds=1",
+                    "namastack.outbox.instance.heartbeat-interval-seconds=1",
+                    "namastack.outbox.instance.graceful-shutdown-timeout-seconds=1",
+                ).run { context ->
+                    assertThat(context).hasNotFailed()
+                    assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
+                    val properties = assertThat(context).getBean(OutboxProperties::class.java).actual()
+                    assertThat(properties.instance.staleInstanceTimeout.seconds).isEqualTo(1)
+                    assertThat(properties.instance.heartbeatInterval.seconds).isEqualTo(1)
+                    assertThat(properties.instance.gracefulShutdownTimeout.seconds).isEqualTo(1)
                 }
         }
     }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.scheduling.TaskScheduler
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -25,12 +26,13 @@ class OutboxInstanceRegistryTest {
     private val now = Instant.now(clock)
 
     private val instanceRepository = mockk<OutboxInstanceRepository>()
+    private val taskScheduler = mockk<TaskScheduler>()
     private val properties =
         OutboxProperties(
             instance =
                 OutboxProperties.Instance(
-                    staleInstanceTimeout = Duration.ofSeconds(2),
-                    heartbeatInterval = Duration.ofSeconds(1),
+                    staleInstanceTimeoutValue = Duration.ofSeconds(2),
+                    heartbeatIntervalValue = Duration.ofSeconds(1),
                 ),
         )
 
@@ -38,7 +40,7 @@ class OutboxInstanceRegistryTest {
 
     @BeforeEach
     fun setUp() {
-        registry = OutboxInstanceRegistry(instanceRepository, properties, clock)
+        registry = OutboxInstanceRegistry(instanceRepository, properties, clock, taskScheduler)
 
         every { instanceRepository.save(any()) } returns mockk()
         every { instanceRepository.findActiveInstances() } returns emptyList()
@@ -335,9 +337,9 @@ class OutboxInstanceRegistryTest {
         fun `use custom graceful shutdown timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(gracefulShutdownTimeout = Duration.ofSeconds(2)),
+                    instance = properties.instance.copy(gracefulShutdownTimeoutValue = Duration.ofSeconds(2)),
                 )
-            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock)
+            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock, taskScheduler)
 
             customRegistry.start()
             customRegistry.stop()
@@ -351,9 +353,9 @@ class OutboxInstanceRegistryTest {
         fun `use custom stale instance timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(staleInstanceTimeout = Duration.ofSeconds(5)),
+                    instance = properties.instance.copy(staleInstanceTimeoutValue = Duration.ofSeconds(5)),
                 )
-            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock)
+            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock, taskScheduler)
             val expectedCutoff = now.minus(Duration.ofSeconds(5))
 
             customRegistry.performHeartbeatAndCleanup()

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
@@ -29,8 +29,8 @@ class OutboxInstanceRegistryTest {
         OutboxProperties(
             instance =
                 OutboxProperties.Instance(
-                    staleInstanceTimeoutSeconds = 2,
-                    heartbeatIntervalSeconds = 1,
+                    staleInstanceTimeout = Duration.ofSeconds(2),
+                    heartbeatInterval = Duration.ofSeconds(1),
                 ),
         )
 
@@ -335,7 +335,7 @@ class OutboxInstanceRegistryTest {
         fun `use custom graceful shutdown timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(gracefulShutdownTimeoutSeconds = 2),
+                    instance = properties.instance.copy(gracefulShutdownTimeout = Duration.ofSeconds(2)),
                 )
             val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock)
 
@@ -351,7 +351,7 @@ class OutboxInstanceRegistryTest {
         fun `use custom stale instance timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(staleInstanceTimeoutSeconds = 5),
+                    instance = properties.instance.copy(staleInstanceTimeout = Duration.ofSeconds(5)),
                 )
             val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock)
             val expectedCutoff = now.minus(Duration.ofSeconds(5))

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox
 
+import io.micrometer.observation.ObservationRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -24,9 +25,10 @@ import java.time.ZoneOffset
 class OutboxInstanceRegistryTest {
     private val clock = Clock.fixed(Instant.parse("2025-10-25T10:00:00Z"), ZoneOffset.UTC)
     private val now = Instant.now(clock)
+    private val observationRegistry = { ObservationRegistry.NOOP }
 
     private val instanceRepository = mockk<OutboxInstanceRepository>()
-    private val taskScheduler = mockk<TaskScheduler>()
+    private val taskScheduler = mockk<TaskScheduler>(relaxed = true)
     private val properties =
         OutboxProperties(
             instance =
@@ -40,7 +42,7 @@ class OutboxInstanceRegistryTest {
 
     @BeforeEach
     fun setUp() {
-        registry = OutboxInstanceRegistry(instanceRepository, properties, clock, taskScheduler)
+        registry = OutboxInstanceRegistry(instanceRepository, properties, clock, taskScheduler, observationRegistry)
 
         every { instanceRepository.save(any()) } returns mockk()
         every { instanceRepository.findActiveInstances() } returns emptyList()
@@ -339,7 +341,14 @@ class OutboxInstanceRegistryTest {
                 properties.copy(
                     instance = properties.instance.copy(gracefulShutdownTimeoutValue = Duration.ofSeconds(2)),
                 )
-            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock, taskScheduler)
+            val customRegistry =
+                OutboxInstanceRegistry(
+                    instanceRepository,
+                    customProperties,
+                    clock,
+                    taskScheduler,
+                    observationRegistry,
+                )
 
             customRegistry.start()
             customRegistry.stop()
@@ -355,7 +364,14 @@ class OutboxInstanceRegistryTest {
                 properties.copy(
                     instance = properties.instance.copy(staleInstanceTimeoutValue = Duration.ofSeconds(5)),
                 )
-            val customRegistry = OutboxInstanceRegistry(instanceRepository, customProperties, clock, taskScheduler)
+            val customRegistry =
+                OutboxInstanceRegistry(
+                    instanceRepository,
+                    customProperties,
+                    clock,
+                    taskScheduler,
+                    observationRegistry,
+                )
             val expectedCutoff = now.minus(Duration.ofSeconds(5))
 
             customRegistry.performHeartbeatAndCleanup()

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxInstanceRegistryTest.kt
@@ -33,8 +33,8 @@ class OutboxInstanceRegistryTest {
         OutboxProperties(
             instance =
                 OutboxProperties.Instance(
-                    staleInstanceTimeoutValue = Duration.ofSeconds(2),
-                    heartbeatIntervalValue = Duration.ofSeconds(1),
+                    staleInstanceTimeout = Duration.ofSeconds(2),
+                    heartbeatInterval = Duration.ofSeconds(1),
                 ),
         )
 
@@ -339,7 +339,7 @@ class OutboxInstanceRegistryTest {
         fun `use custom graceful shutdown timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(gracefulShutdownTimeoutValue = Duration.ofSeconds(2)),
+                    instance = properties.instance.copy(gracefulShutdownTimeout = Duration.ofSeconds(2)),
                 )
             val customRegistry =
                 OutboxInstanceRegistry(
@@ -362,7 +362,7 @@ class OutboxInstanceRegistryTest {
         fun `use custom stale instance timeout`() {
             val customProperties =
                 properties.copy(
-                    instance = properties.instance.copy(staleInstanceTimeoutValue = Duration.ofSeconds(5)),
+                    instance = properties.instance.copy(staleInstanceTimeout = Duration.ofSeconds(5)),
                 )
             val customRegistry =
                 OutboxInstanceRegistry(

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxProcessingSchedulerTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxProcessingSchedulerTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.core.task.SyncTaskExecutor
 import org.springframework.scheduling.TaskScheduler
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.util.concurrent.CountDownLatch
@@ -235,7 +236,7 @@ class OutboxProcessingSchedulerTest {
         fun `stop cancels after shutdown timeout when processing is still running`() {
             val properties =
                 OutboxProperties().apply {
-                    processing.shutdownTimeoutSeconds = 0
+                    processing.shutdownTimeout = Duration.ofSeconds(0)
                 }
             scheduler =
                 OutboxProcessingScheduler(

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyFactoryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyFactoryTest.kt
@@ -43,7 +43,7 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "fixed",
-                        fixedDelayMs = 3000,
+                        fixedDelay = Duration.ofSeconds(3),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -57,8 +57,8 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "fixed",
-                        fixedDelayMs = 5000,
-                        jitterMs = 2000,
+                        fixedDelay = Duration.ofSeconds(5),
+                        jitter = Duration.ofSeconds(2),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -83,9 +83,9 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "linear",
-                        linearInitialMs = 1000,
-                        linearIncrementMs = 2000,
-                        linearMaxMs = 7000,
+                        linearInitial = Duration.ofSeconds(1),
+                        linearIncrement = Duration.ofSeconds(2),
+                        linearMax = Duration.ofSeconds(7),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -102,10 +102,10 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "linear",
-                        linearInitialMs = 1000,
-                        linearIncrementMs = 2000,
-                        linearMaxMs = 7000,
-                        jitterMs = 500,
+                        linearInitial = Duration.ofSeconds(1),
+                        linearIncrement = Duration.ofSeconds(2),
+                        linearMax = Duration.ofSeconds(7),
+                        jitter = Duration.ofMillis(500),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -130,9 +130,9 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "exponential",
-                        exponentialInitialMs = 1000,
+                        exponentialInitial = Duration.ofSeconds(1),
                         exponentialMultiplier = 2.0,
-                        exponentialMaxMs = 9000,
+                        exponentialMax = Duration.ofSeconds(9),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -149,10 +149,10 @@ class OutboxRetryPolicyFactoryTest {
                 val prop =
                     properties(
                         policy = "exponential",
-                        exponentialInitialMs = 1000,
+                        exponentialInitial = Duration.ofSeconds(1),
                         exponentialMultiplier = 2.0,
-                        exponentialMaxMs = 9000,
-                        jitterMs = 500,
+                        exponentialMax = Duration.ofSeconds(9),
+                        jitter = Duration.ofMillis(500),
                     )
                 val policy = OutboxRetryPolicyFactory.createDefault(prop).build()
 
@@ -227,14 +227,14 @@ class OutboxRetryPolicyFactoryTest {
     private fun properties(
         maxRetries: Int? = null,
         policy: String? = null,
-        fixedDelayMs: Long? = null,
-        linearInitialMs: Long? = null,
-        linearIncrementMs: Long? = null,
-        linearMaxMs: Long? = null,
-        exponentialInitialMs: Long? = null,
+        fixedDelay: Duration? = null,
+        linearInitial: Duration? = null,
+        linearIncrement: Duration? = null,
+        linearMax: Duration? = null,
+        exponentialInitial: Duration? = null,
         exponentialMultiplier: Double? = null,
-        exponentialMaxMs: Long? = null,
-        jitterMs: Long? = null,
+        exponentialMax: Duration? = null,
+        jitter: Duration? = null,
         include: Set<String>? = null,
         exclude: Set<String>? = null,
     ): OutboxProperties.Retry {
@@ -242,14 +242,14 @@ class OutboxRetryPolicyFactoryTest {
 
         maxRetries?.let { properties.maxRetries = it }
         policy?.let { properties.policy = it }
-        fixedDelayMs?.let { properties.fixed.delay = it }
-        linearInitialMs?.let { properties.linear.initialDelay = it }
-        linearIncrementMs?.let { properties.linear.increment = it }
-        linearMaxMs?.let { properties.linear.maxDelay = it }
-        exponentialInitialMs?.let { properties.exponential.initialDelay = it }
+        fixedDelay?.let { properties.fixed.delay = it }
+        linearInitial?.let { properties.linear.initialDelay = it }
+        linearIncrement?.let { properties.linear.increment = it }
+        linearMax?.let { properties.linear.maxDelay = it }
+        exponentialInitial?.let { properties.exponential.initialDelay = it }
         exponentialMultiplier?.let { properties.exponential.multiplier = it }
-        exponentialMaxMs?.let { properties.exponential.maxDelay = it }
-        jitterMs?.let { properties.jitter = it }
+        exponentialMax?.let { properties.exponential.maxDelay = it }
+        jitter?.let { properties.jitter = it }
         include?.let { properties.includeExceptions = it }
         exclude?.let { properties.excludeExceptions = it }
 

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/trigger/OutboxPollingTriggerFactoryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/trigger/OutboxPollingTriggerFactoryTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.scheduling.TriggerContext
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 
@@ -27,7 +28,7 @@ class OutboxPollingTriggerFactoryTest {
             val prop =
                 properties(
                     pollingTrigger = "fixed",
-                    fixedInterval = 3000,
+                    fixedInterval = Duration.ofSeconds(3),
                 )
             every { triggerContext.lastCompletion() } returns instant
 
@@ -42,7 +43,7 @@ class OutboxPollingTriggerFactoryTest {
         fun `fixed trigger using deprecated pollInterval`() {
             val prop =
                 properties(
-                    pollInterval = 3000,
+                    pollInterval = Duration.ofSeconds(3),
                     pollingTrigger = "fixed",
                 )
             every { triggerContext.lastCompletion() } returns instant
@@ -61,8 +62,8 @@ class OutboxPollingTriggerFactoryTest {
             properties(
                 pollingBatchSize = 20,
                 pollingTrigger = "adaptive",
-                adaptiveMinInterval = 2000,
-                adaptiveMaxInterval = 4000,
+                adaptiveMinInterval = Duration.ofSeconds(2),
+                adaptiveMaxInterval = Duration.ofSeconds(4),
             )
         every { triggerContext.lastCompletion() } returns instant
 
@@ -90,13 +91,13 @@ class OutboxPollingTriggerFactoryTest {
     }
 
     private fun properties(
-        pollInterval: Long? = null,
+        pollInterval: Duration? = null,
         batchSize: Int? = null,
         pollingBatchSize: Int? = null,
         pollingTrigger: String? = null,
-        fixedInterval: Long? = null,
-        adaptiveMinInterval: Long? = null,
-        adaptiveMaxInterval: Long? = null,
+        fixedInterval: Duration? = null,
+        adaptiveMinInterval: Duration? = null,
+        adaptiveMaxInterval: Duration? = null,
     ): OutboxProperties {
         val properties = OutboxProperties()
 

--- a/namastack-outbox-docs/docs/quickstart.mdx
+++ b/namastack-outbox-docs/docs/quickstart.mdx
@@ -254,26 +254,26 @@ Both approaches work equally well. Choose based on your preference:
 ```yaml
 namastack:
   outbox:
-    poll-interval: 2000
+    poll-interval: 2s
     batch-size: 10
     retry:
       policy: "exponential"
       max-retries: 3
       exponential:
-        initial-delay: 1000
-        max-delay: 60000
+        initial-delay: 1s
+        max-delay: 1m
         multiplier: 2.0
 ```
 </TabItem>
 <TabItem value="Properties" label="Properties">
 
 ```properties
-namastack.outbox.poll-interval=2000
+namastack.outbox.poll-interval=2s
 namastack.outbox.batch-size=10
 namastack.outbox.retry.policy=exponential
 namastack.outbox.retry.max-retries=3
-namastack.outbox.retry.exponential.initial-delay=1000
-namastack.outbox.retry.exponential.max-delay=60000
+namastack.outbox.retry.exponential.initial-delay=1s
+namastack.outbox.retry.exponential.max-delay=1m
 namastack.outbox.retry.exponential.multiplier=2.0
 ```
 </TabItem>

--- a/namastack-outbox-docs/docs/reference/configuration.md
+++ b/namastack-outbox-docs/docs/reference/configuration.md
@@ -82,7 +82,7 @@ namastack:
       
       # Exponential Backoff Policy
       exponential:
-        initial-delay: 1s                      # Initial delay (default: 1s)
+        initial-delay: 2s                      # Initial delay (default: 2s)
         max-delay: 1m                          # Maximum delay cap (default: 1m)
         multiplier: 2.0                        # Backoff multiplier (default: 2.0)
       

--- a/namastack-outbox-docs/docs/reference/configuration.md
+++ b/namastack-outbox-docs/docs/reference/configuration.md
@@ -15,17 +15,17 @@ namastack:
 
     # Polling Configuration
     polling:
-      trigger: fixed                          # Polling strategy: fixed|adaptive (default: fixed)
-      batch-size: 10                          # Record keys per poll cycle (default: 10)
+      trigger: fixed                           # Polling strategy: fixed|adaptive (default: fixed)
+      batch-size: 10                           # Record keys per poll cycle (default: 10)
       fixed:
-        interval: 2s                          # interval between polling cycles (default: 2s)
+        interval: 2s                           # interval between polling cycles (default: 2s)
       adaptive:
-        min-interval: 1s                      # Minimum ms between cycles (default: 1s)
-        max-interval: 8s                      # Maximum ms between cycles (default: 8s)
+        min-interval: 1s                       # Minimum ms between cycles (default: 1s)
+        max-interval: 8s                       # Maximum ms between cycles (default: 8s)
     # Legacy (deprecated)
-    poll-interval: 2s                         # (deprecated) Use polling.fixed.interval
-    rebalance-interval: 10s                   # (deprecated) Use instance.rebalance-interval
-    batch-size: 10                            # (deprecated) Use polling.batch-size
+    poll-interval: 2s                          # (deprecated) Use polling.fixed.interval
+    rebalance-interval: 10s                    # (deprecated) Use instance.rebalance-interval
+    batch-size: 10                             # (deprecated) Use polling.batch-size
 
     # Processing Configuration
     processing:
@@ -34,6 +34,8 @@ namastack:
       executor-core-pool-size: 4               # Core threads for processing (default: 4, platform threads)
       executor-max-pool-size: 8                # Maximum threads for processing (default: 8, platform threads)
       executor-concurrency-limit: -1           # Concurrency limit for virtual threads (default: -1 unlimited)
+      shutdown-timeout-seconds: 30             # (deprecated) Use shutdown-timeout
+      shutdown-timeout: 30s                    # Maximum time to wait for processing to complete during shutdown (default: 30s)
 
     # Event Multicaster Configuration
     multicaster:
@@ -91,15 +93,20 @@ namastack:
 
     # Kafka Integration
     kafka:
-      enabled: true                           # Enable Kafka outbox integration (default: true)
-      default-topic: outbox-events            # Default Kafka topic (default: outbox-events)
-      enable-json: true                       # Enable JSON support (default: true)
+      enabled: true                            # Enable Kafka outbox integration (default: true)
+      default-topic: outbox-events             # Default Kafka topic (default: outbox-events)
+      enable-json: true                        # Enable JSON support (default: true)
 
     # RabbitMQ Integration
     rabbit:
-      enabled: true                           # Enable Rabbit outbox integration (default: true)
-      default-exchange: outbox-events         # Default Rabbit exchange (default: outbox-events)
-      enable-json: true                       # Enable JSON support (default: true)
+      enabled: true                            # Enable Rabbit outbox integration (default: true)
+      default-exchange: outbox-events          # Default Rabbit exchange (default: outbox-events)
+      enable-json: true                        # Enable JSON support (default: true)
+
+    # SNS Integration
+    sns:
+      enabled: true                            # Enable SNS outbox integration (default: true)
+      default-topic-arn: arn:aws:sns:us-east-1:000000000000:outbox-events   # Default SNS topic ARN (default: arn:aws:sns:us-east-1:000000000000:outbox-events)
 ```
 
 ---
@@ -145,4 +152,3 @@ namastack:
   outbox:
     enabled: false
 ```
-

--- a/namastack-outbox-docs/docs/reference/configuration.md
+++ b/namastack-outbox-docs/docs/reference/configuration.md
@@ -18,13 +18,13 @@ namastack:
       trigger: fixed                          # Polling strategy: fixed|adaptive (default: fixed)
       batch-size: 10                          # Record keys per poll cycle (default: 10)
       fixed:
-        interval: 2000                        # Milliseconds between polling cycles (default: 2000)
+        interval: 2s                          # interval between polling cycles (default: 2s)
       adaptive:
-        min-interval: 1000                    # Minimum ms between cycles (default: 1000)
-        max-interval: 8000                    # Maximum ms between cycles (default: 8000)
+        min-interval: 1s                      # Minimum ms between cycles (default: 1s)
+        max-interval: 8s                      # Maximum ms between cycles (default: 8s)
     # Legacy (deprecated)
-    poll-interval: 2000                       # (deprecated) Use polling.fixed.interval
-    rebalance-interval: 10000                 # (deprecated) Use instance.rebalance-interval
+    poll-interval: 2s                         # (deprecated) Use polling.fixed.interval
+    rebalance-interval: 10s                   # (deprecated) Use instance.rebalance-interval
     batch-size: 10                            # (deprecated) Use polling.batch-size
 
     # Processing Configuration
@@ -42,10 +42,13 @@ namastack:
 
     # Instance Coordination Configuration
     instance:
-      graceful-shutdown-timeout-seconds: 0     # Graceful shutdown propagation window (default: 0)
-      stale-instance-timeout-seconds: 30       # When an instance is considered stale and removed (default: 30)
-      heartbeat-interval-seconds: 5            # How often each instance sends a heartbeat (default: 5)
-      rebalance-interval: 10000                # How often partitions are recalculated (default: 10000)
+      graceful-shutdown-timeout-seconds: 0     # (deprecated) Use graceful-shutdown-timeout
+      stale-instance-timeout-seconds: 30       # (deprecated) Use stale-instance-timeout
+      heartbeat-interval-seconds: 5            # (deprecated) Use heartbeat-interval
+      graceful-shutdown-timeout: 0s            # Graceful shutdown propagation window (default: 0s)
+      stale-instance-timeout: 30s              # When an instance is considered stale and removed (default: 30s)
+      heartbeat-interval: 5s                   # How often each instance sends a heartbeat (default: 5s)
+      rebalance-interval: 10s                  # How often partitions are recalculated (default: 10s)
 
     jdbc:
       table-prefix: ""                         # Prefix for table names (default: empty)
@@ -69,22 +72,22 @@ namastack:
       
       # Fixed Delay Policy
       fixed:
-        delay: 5000                            # Delay in milliseconds (default: 5000)
+        delay: 5s                              # Delay (default: 5s)
       
       # Linear Backoff Policy
       linear:
-        initial-delay: 2000                    # Initial delay in milliseconds (default: 2000)
-        increment: 2000                        # Increment per retry in milliseconds (default: 2000)
-        max-delay: 60000                       # Maximum delay cap in milliseconds (default: 60000)
+        initial-delay: 2s                      # Initial delay  (default: 2s)
+        increment: 2s                          # Increment per retry (default: 2s)
+        max-delay: 1m                          # Maximum delay cap (default: 1m)
       
       # Exponential Backoff Policy
       exponential:
-        initial-delay: 1000                    # Initial delay in milliseconds (default: 1000)
-        max-delay: 60000                       # Maximum delay cap in milliseconds (default: 60000)
+        initial-delay: 1s                      # Initial delay (default: 1s)
+        max-delay: 1m                          # Maximum delay cap (default: 1m)
         multiplier: 2.0                        # Backoff multiplier (default: 2.0)
       
       # Jitter Configuration (can be used with any policy)
-      jitter: 0                                # Max random jitter in milliseconds (default: 0)
+      jitter: 0s                               # Max random jitter (default: 0s)
 
     # Kafka Integration
     kafka:

--- a/namastack-outbox-docs/docs/reference/polling.md
+++ b/namastack-outbox-docs/docs/reference/polling.md
@@ -24,14 +24,14 @@ import TabItem from '@theme/TabItem';
 
 **Configuration Options:**
 
-| Property                                  | Default   | Description                                  |
-|-------------------------------------------|-----------|----------------------------------------------|
-| `namastack.outbox.polling.trigger`        | `fixed`   | Selects polling strategy                     |
-| `namastack.outbox.polling.fixed.interval` | `2000` ms | Interval in milliseconds between poll cycles |
-| `namastack.outbox.polling.batch-size`     | `10`      | Max record keys to process per poll          |
+| Property                                  | Default | Description                                                                   |
+|-------------------------------------------|---------|-------------------------------------------------------------------------------|
+| `namastack.outbox.polling.trigger`        | `fixed` | Selects polling strategy                                                      |
+| `namastack.outbox.polling.fixed.interval` | `2s`    | Interval between poll cycles (supports duration strings, e.g., `2s`, `500ms`) |
+| `namastack.outbox.polling.batch-size`     | `10`    | Max record keys to process per poll                                           |
 
 </TabItem>
-<TabItem value="adaptive" label="Adaptive Polling (since v1.1.0)">
+<TabItem value="adaptive" label="Adaptive Polling">
 
 **How it works:**
 
@@ -46,12 +46,12 @@ import TabItem from '@theme/TabItem';
 
 **Configuration Options:**
 
-| Property                                         | Default    | Description                             |
-|--------------------------------------------------|------------|-----------------------------------------|
-| `namastack.outbox.polling.trigger`               | `adaptive` | Selects polling strategy                |
-| `namastack.outbox.polling.adaptive.min-interval` | `1000` ms  | Minimum interval between polling cycles |
-| `namastack.outbox.polling.adaptive.max-interval` | `8000` ms  | Maximum interval between polling cycles |
-| `namastack.outbox.polling.batch-size`            | `10`       | Max record keys to process per poll     |
+| Property                                         | Default    | Description                                                         |
+|--------------------------------------------------|------------|---------------------------------------------------------------------|
+| `namastack.outbox.polling.trigger`               | `adaptive` | Selects polling strategy                                            |
+| `namastack.outbox.polling.adaptive.min-interval` | `1s`       | Minimum interval between polling cycles (supports duration strings) |
+| `namastack.outbox.polling.adaptive.max-interval` | `8s`       | Maximum interval between polling cycles (supports duration strings) |
+| `namastack.outbox.polling.batch-size`            | `10`       | Max record keys to process per poll                                 |
 
 </TabItem>
 </Tabs>

--- a/namastack-outbox-docs/docs/reference/processing.md
+++ b/namastack-outbox-docs/docs/reference/processing.md
@@ -136,3 +136,22 @@ sequenceDiagram
     F->>PF: Handle Permanent Failure
     PF->>DB: Mark FAILED ✗
 ```
+
+---
+
+## Processing Configuration Options
+
+The following options control how records are processed:
+
+| Property                                                 | Default | Description                                                     |
+|----------------------------------------------------------|---------|-----------------------------------------------------------------|
+| `namastack.outbox.processing.stop-on-first-failure`      | `true`  | Stop processing on first failure                                |
+| `namastack.outbox.processing.delete-completed-records`   | `false` | Delete records after completion                                 |
+| `namastack.outbox.processing.executor-core-pool-size`    | `4`     | Core threads for processing (platform threads)                  |
+| `namastack.outbox.processing.executor-max-pool-size`     | `8`     | Maximum threads for processing (platform threads)               |
+| `namastack.outbox.processing.executor-concurrency-limit` | `-1`    | Concurrency limit for virtual threads (`-1` unlimited)          |
+| `namastack.outbox.processing.shutdown-timeout-seconds`   | `30`    | (deprecated) Use `shutdown-timeout`                             |
+| `namastack.outbox.processing.shutdown-timeout`           | `30s`   | Maximum time to wait for processing to complete during shutdown |
+
+- `shutdown-timeout-seconds` is deprecated and will be removed in a future release. Use `shutdown-timeout` instead.
+- Both options control the maximum time the system will wait for in-flight processing to complete during a graceful shutdown.

--- a/namastack-outbox-docs/docs/reference/retry.md
+++ b/namastack-outbox-docs/docs/reference/retry.md
@@ -28,7 +28,7 @@ namastack:
       policy: "fixed"
       max-retries: 5
       fixed:
-        delay: 5000  # 5 seconds between retries
+        delay: 5s  # 5 seconds between retries
 ```
 
 **Use Case:** Simple scenarios with consistent retry intervals
@@ -46,9 +46,9 @@ namastack:
       policy: "linear"
       max-retries: 5
       linear:
-        initial-delay: 2000    # Start with 2 seconds
-        increment: 2000        # Add 2 seconds each retry
-        max-delay: 60000       # Cap at 1 minute
+        initial-delay: 2s    # Start with 2 seconds
+        increment: 2s        # Add 2 seconds each retry
+        max-delay: 60s       # Cap at 1 minute
 ```
 
 **Use Case:** Gradually increasing delays for services that need time to recover
@@ -66,9 +66,9 @@ namastack:
       policy: "exponential"
       max-retries: 3
       exponential:
-        initial-delay: 1000    # Start with 1 second
-        max-delay: 60000       # Cap at 1 minute
-        multiplier: 2.0        # Double each time
+        initial-delay: 1s    # Start with 1 second
+        max-delay: 60s       # Cap at 1 minute
+        multiplier: 2.0      # Double each time
 ```
 
 **Use Case:** Handles transient failures gracefully without overwhelming downstream services
@@ -86,10 +86,10 @@ namastack:
       policy: "exponential"  # Can also be "fixed" or "linear"
       max-retries: 7
       exponential:
-        initial-delay: 2000
-        max-delay: 60000
+        initial-delay: 2s
+        max-delay: 60s
         multiplier: 2.0
-      jitter: 1000  # Add [-1000ms, 1000ms] random delay
+      jitter: 1s  # Add [-1s, 1s] random delay
 ```
 
 **Benefits:** Prevents coordinated retry storms when multiple instances retry simultaneously

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
@@ -1,6 +1,5 @@
 package io.namastack.outbox
 
-import io.mockk.mockk
 import io.namastack.outbox.config.OutboxCoreSchedulingAutoConfiguration
 import io.namastack.outbox.instance.OutboxInstanceRegistry
 import io.namastack.outbox.instance.OutboxInstanceRepository
@@ -15,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Import
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.transaction.annotation.Propagation
@@ -28,10 +28,12 @@ import java.util.concurrent.TimeUnit.SECONDS
 @DirtiesContext
 @OutboxIntegrationTest
 @ImportAutoConfiguration(exclude = [OutboxCoreSchedulingAutoConfiguration::class])
+@Import(TaskSchedulerConfiguration::class)
 class PartitioningIntegrationTest {
     private val clock: Clock = Clock.systemDefaultZone()
 
-    private val taskScheduler: TaskScheduler = mockk()
+    @Autowired
+    private lateinit var taskScheduler: TaskScheduler
 
     @Autowired
     private lateinit var partitionAssignmentRepository: PartitionAssignmentRepository

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox
 
+import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.config.OutboxCoreSchedulingAutoConfiguration
 import io.namastack.outbox.instance.OutboxInstanceRegistry
 import io.namastack.outbox.instance.OutboxInstanceRepository
@@ -146,6 +147,7 @@ class PartitioningIntegrationTest {
                 properties = outboxProperties,
                 clock = clock,
                 taskScheduler = taskScheduler,
+                observationRegistry = { ObservationRegistry.NOOP },
             )
 
         instanceRegistry.registerInstance()

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.scheduling.TaskScheduler
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +29,9 @@ import java.util.concurrent.TimeUnit.SECONDS
 @ImportAutoConfiguration(exclude = [OutboxCoreSchedulingAutoConfiguration::class])
 class PartitioningIntegrationTest {
     private val clock: Clock = Clock.systemDefaultZone()
+
+    @Autowired
+    private lateinit var taskScheduler: TaskScheduler
 
     @Autowired
     private lateinit var partitionAssignmentRepository: PartitionAssignmentRepository
@@ -139,6 +143,7 @@ class PartitioningIntegrationTest {
                 instanceRepository = instanceRepository,
                 properties = outboxProperties,
                 clock = clock,
+                taskScheduler = taskScheduler,
             )
 
         instanceRegistry.registerInstance()

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox
 
+import io.mockk.mockk
 import io.namastack.outbox.config.OutboxCoreSchedulingAutoConfiguration
 import io.namastack.outbox.instance.OutboxInstanceRegistry
 import io.namastack.outbox.instance.OutboxInstanceRepository
@@ -30,8 +31,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 class PartitioningIntegrationTest {
     private val clock: Clock = Clock.systemDefaultZone()
 
-    @Autowired
-    private lateinit var taskScheduler: TaskScheduler
+    private val taskScheduler: TaskScheduler = mockk()
 
     @Autowired
     private lateinit var partitionAssignmentRepository: PartitionAssignmentRepository

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/TaskSchedulerConfiguration.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/TaskSchedulerConfiguration.kt
@@ -1,0 +1,12 @@
+package io.namastack.outbox
+
+import io.mockk.mockk
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+
+@Configuration
+class TaskSchedulerConfiguration {
+    @Bean
+    fun taskScheduler(): TaskScheduler = mockk(relaxed = true)
+}

--- a/namastack-outbox-integration-tests/src/test/resources/application.yml
+++ b/namastack-outbox-integration-tests/src/test/resources/application.yml
@@ -13,7 +13,7 @@ namastack:
     retry:
       policy: "fixed"
       fixed:
-        delay: 1000
+        delay: "1s"
       max-retries: 2
 
 logging:

--- a/namastack-outbox-performance-tests/namastack-outbox-performance-test-processor/src/main/resources/application.yml
+++ b/namastack-outbox-performance-tests/namastack-outbox-performance-test-processor/src/main/resources/application.yml
@@ -36,24 +36,24 @@ namastack:
       policy: exponential
       max-retries: 3
       exponential:
-        initial-delay: 1000
-        max-delay: 60000
+        initial-delay: "1s"
+        max-delay: "1m"
         multiplier: 2.0
-      jitter: 1000
+      jitter: "1s"
     polling:
       batch-size: 1200
       trigger: fixed
       fixed:
-        interval: 1000
+        interval: "1s"
     processing:
       stop-on-first-failure: true
       delete-completed-records: true
       executor-core-pool-size: 16
       executor-max-pool-size: 32
     instance:
-      heartbeat-interval-seconds: 5
-      stale-instance-timeout-seconds: 10
-      rebalance-interval: 10000
+      heartbeat-interval: "5s"
+      stale-instance-timeout: "10s"
+      rebalance-interval: "10s"
     multicaster:
       publish-after-save: false
 

--- a/namastack-outbox-tracing/src/test/kotlin/resources/application.yml
+++ b/namastack-outbox-tracing/src/test/kotlin/resources/application.yml
@@ -13,7 +13,7 @@ namastack:
     retry:
       policy: "fixed"
       fixed:
-        delay: 100
+        delay: "100ms"
       max-retries: 2
 
 logging:


### PR DESCRIPTION
Should solve most of the things suggested in #267.
One breaking change I think: The `@Scheduled`annotation in `io.namastack.outbox.instance.OutboxInstanceRegistry`