### PR TITLE
Add partition lease ownership and draining handoff

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProcessingScheduler.kt
@@ -3,6 +3,8 @@ package io.namastack.outbox
 import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.OutboxRecordStatus.NEW
 import io.namastack.outbox.partition.PartitionCoordinator
+import io.namastack.outbox.partition.PartitionDrainTracker
+import io.namastack.outbox.partition.PartitionHasher
 import io.namastack.outbox.processor.OutboxRecordProcessor
 import io.namastack.outbox.trigger.OutboxPollingTrigger
 import org.slf4j.LoggerFactory
@@ -49,6 +51,7 @@ class OutboxProcessingScheduler(
     private val recordRepository: OutboxRecordRepository,
     private val recordProcessorChain: OutboxRecordProcessor,
     private val partitionCoordinator: PartitionCoordinator,
+    private val partitionDrainTracker: PartitionDrainTracker = PartitionDrainTracker(),
     private val taskExecutor: TaskExecutor,
     private val properties: OutboxProperties,
     private val clock: Clock,
@@ -174,6 +177,8 @@ class OutboxProcessingScheduler(
     }
 
     private fun processRecordKey(recordKey: String) {
+        val partitionNumber = PartitionHasher.getPartitionForRecordKey(recordKey)
+        partitionDrainTracker.start(partitionNumber)
         try {
             val records = recordRepository.findIncompleteRecordsByRecordKey(recordKey)
             if (records.isEmpty()) return
@@ -185,6 +190,8 @@ class OutboxProcessingScheduler(
             }
         } catch (ex: Exception) {
             log.error("Error processing key {}", recordKey, ex)
+        } finally {
+            partitionDrainTracker.finish(partitionNumber)
         }
     }
 

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxProperties.kt
@@ -34,6 +34,7 @@ data class OutboxProperties(
     var polling: Polling = Polling(),
     var retry: Retry = Retry(),
     var processing: Processing = Processing(),
+    var partition: Partition = Partition(),
     var instance: Instance = Instance(),
     var multicaster: Multicaster = Multicaster(),
 ) {
@@ -94,6 +95,15 @@ data class OutboxProperties(
         var executorMaxPoolSize: Int = 8,
         var executorConcurrencyLimit: Int = -1,
         var shutdownTimeoutSeconds: Long = 30,
+    )
+
+    /**
+     * Configuration for partition lease ownership and draining.
+     *
+     * @param leaseDurationSeconds How long a partition lease remains valid without renewal
+     */
+    data class Partition(
+        var leaseDurationSeconds: Long = 30,
     )
 
     /**

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -16,6 +16,7 @@ import io.namastack.outbox.instance.OutboxInstanceRepository
 import io.namastack.outbox.partition.PartitionAssignmentCache
 import io.namastack.outbox.partition.PartitionAssignmentRepository
 import io.namastack.outbox.partition.PartitionCoordinator
+import io.namastack.outbox.partition.PartitionDrainTracker
 import io.namastack.outbox.retry.OutboxRetryPolicy
 import io.namastack.outbox.retry.OutboxRetryPolicyFactory
 import io.namastack.outbox.retry.OutboxRetryPolicyRegistry
@@ -76,12 +77,16 @@ class OutboxCoreInfrastructureAutoConfiguration {
         instanceRegistry: OutboxInstanceRegistry,
         partitionAssignmentRepository: PartitionAssignmentRepository,
         partitionAssignmentCache: PartitionAssignmentCache,
+        partitionDrainTracker: PartitionDrainTracker,
+        properties: OutboxProperties,
         clock: Clock,
     ): PartitionCoordinator =
         PartitionCoordinator(
             instanceRegistry = instanceRegistry,
             partitionAssignmentRepository = partitionAssignmentRepository,
             partitionAssignmentCache = partitionAssignmentCache,
+            partitionDrainTracker = partitionDrainTracker,
+            properties = properties,
             clock = clock,
         )
 
@@ -93,6 +98,10 @@ class OutboxCoreInfrastructureAutoConfiguration {
         PartitionAssignmentCache(
             partitionAssignmentRepository = partitionAssignmentRepository,
         )
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun partitionDrainTracker(): PartitionDrainTracker = PartitionDrainTracker()
 
     @Bean("outboxRetryPolicy")
     @ConditionalOnMissingBean(name = ["outboxRetryPolicy"])

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreSchedulingAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreSchedulingAutoConfiguration.kt
@@ -5,6 +5,7 @@ import io.namastack.outbox.OutboxProcessingScheduler
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.OutboxRecordRepository
 import io.namastack.outbox.partition.PartitionCoordinator
+import io.namastack.outbox.partition.PartitionDrainTracker
 import io.namastack.outbox.processor.OutboxRecordProcessor
 import io.namastack.outbox.trigger.OutboxPollingTrigger
 import io.namastack.outbox.trigger.OutboxPollingTriggerFactory
@@ -48,6 +49,7 @@ class OutboxCoreSchedulingAutoConfiguration {
         recordRepository: OutboxRecordRepository,
         recordProcessorChain: OutboxRecordProcessor,
         partitionCoordinator: PartitionCoordinator,
+        partitionDrainTracker: PartitionDrainTracker,
         properties: OutboxProperties,
         clock: Clock,
         beanFactory: BeanFactory,
@@ -62,6 +64,7 @@ class OutboxCoreSchedulingAutoConfiguration {
             recordRepository = recordRepository,
             recordProcessorChain = recordProcessorChain,
             partitionCoordinator = partitionCoordinator,
+            partitionDrainTracker = partitionDrainTracker,
             taskExecutor = taskExecutor,
             properties = properties,
             clock = clock,

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionAssignment.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionAssignment.kt
@@ -1,6 +1,7 @@
 package io.namastack.outbox.partition
 
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 
 /**
@@ -20,9 +21,18 @@ data class PartitionAssignment(
     val partitionNumber: Int,
     var instanceId: String?,
     var updatedAt: Instant,
+    var leaseExpiresAt: Instant? = null,
+    var draining: Boolean = false,
     val version: Long? = null,
 ) {
     companion object {
+        fun create(
+            partitionNumber: Int,
+            instanceId: String,
+            clock: Clock,
+            version: Long?,
+        ): PartitionAssignment = create(partitionNumber, instanceId, clock, Duration.ofSeconds(30), version)
+
         /**
          * Creates a new partition assignment.
          *
@@ -35,6 +45,7 @@ data class PartitionAssignment(
             partitionNumber: Int,
             instanceId: String,
             clock: Clock,
+            leaseDuration: Duration,
             version: Long?,
         ): PartitionAssignment {
             val now = Instant.now(clock)
@@ -42,6 +53,8 @@ data class PartitionAssignment(
                 partitionNumber = partitionNumber,
                 instanceId = instanceId,
                 updatedAt = now,
+                leaseExpiresAt = now.plus(leaseDuration),
+                draining = false,
                 version = version,
             )
         }
@@ -57,11 +70,45 @@ data class PartitionAssignment(
     fun claim(
         instanceId: String,
         clock: Clock,
+        leaseDuration: Duration = Duration.ofSeconds(30),
     ) {
         val now = Instant.now(clock)
 
         this.instanceId = instanceId
         this.updatedAt = now
+        this.leaseExpiresAt = now.plus(leaseDuration)
+        this.draining = false
+    }
+
+    /**
+     * Extends this lease while retaining ownership.
+     */
+    fun renewLease(
+        currentInstanceId: String,
+        clock: Clock,
+        leaseDuration: Duration,
+    ) {
+        ensureOwnedBy(currentInstanceId)
+
+        val now = Instant.now(clock)
+        this.updatedAt = now
+        this.leaseExpiresAt = now.plus(leaseDuration)
+    }
+
+    /**
+     * Marks the partition as draining so the owner stops taking new work for it.
+     */
+    fun markDraining(
+        currentInstanceId: String,
+        clock: Clock,
+        leaseDuration: Duration,
+    ) {
+        ensureOwnedBy(currentInstanceId)
+
+        val now = Instant.now(clock)
+        this.updatedAt = now
+        this.leaseExpiresAt = now.plus(leaseDuration)
+        this.draining = true
     }
 
     /**
@@ -76,15 +123,27 @@ data class PartitionAssignment(
         currentInstanceId: String,
         clock: Clock,
     ) {
-        if (instanceId != currentInstanceId) {
-            throw IllegalStateException(
-                "Could not release partition assignment with partition number $partitionNumber. Instance $currentInstanceId does not own this partition assignment.",
-            )
-        }
+        ensureOwnedBy(currentInstanceId)
 
         val now = Instant.now(clock)
 
         this.instanceId = null
         this.updatedAt = now
+        this.leaseExpiresAt = null
+        this.draining = false
+    }
+
+    fun isLeaseExpired(now: Instant): Boolean = leaseExpiresAt?.let { !it.isAfter(now) } ?: false
+
+    fun isClaimable(now: Instant): Boolean = instanceId == null || isLeaseExpired(now)
+
+    fun isProcessable(now: Instant): Boolean = instanceId != null && !draining && !isLeaseExpired(now)
+
+    private fun ensureOwnedBy(currentInstanceId: String) {
+        if (instanceId != currentInstanceId) {
+            throw IllegalStateException(
+                "Could not update partition assignment with partition number $partitionNumber. Instance $currentInstanceId does not own this partition assignment.",
+            )
+        }
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionAssignmentCache.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionAssignmentCache.kt
@@ -19,8 +19,10 @@ class PartitionAssignmentCache(
      */
     fun getAssignedPartitionNumbers(instanceId: String): Set<Int> =
         cache.computeIfAbsent(instanceId) { id ->
+            val now = java.time.Instant.now()
             partitionAssignmentRepository
                 .findByInstanceId(id)
+                .filter { it.isProcessable(now) }
                 .map { it.partitionNumber }
                 .toSet()
         }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionContext.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionContext.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox.partition
 
+import java.time.Instant
 import kotlin.math.max
 
 /**
@@ -18,6 +19,7 @@ data class PartitionContext(
     val currentInstanceId: String,
     val activeInstanceIds: Set<String>,
     val partitionAssignments: Set<PartitionAssignment>,
+    val now: Instant = Instant.now(),
 ) {
     /**
      * The number of partitions this instance should own according to the distribution algorithm.
@@ -33,6 +35,12 @@ data class PartitionContext(
      * Returns the number of partitions currently owned by this instance.
      */
     fun countOwnedPartitionAssignments(): Int = partitionAssignments.count { it.instanceId == currentInstanceId }
+
+    /**
+     * Returns the number of partitions owned by this instance that are already draining.
+     */
+    fun countOwnedDrainingPartitionAssignments(): Int =
+        partitionAssignments.count { it.instanceId == currentInstanceId && it.draining }
 
     /**
      * Returns the number of partitions that should be released by this instance to reach a balanced state.
@@ -62,8 +70,12 @@ data class PartitionContext(
     /**
      * Returns all partition assignments whose owner is not among active instances (stale candidates).
      */
-    fun getStalePartitionAssignments(): Set<PartitionAssignment> =
-        partitionAssignments.filterNot { it.instanceId in activeInstanceIds }.toSet()
+    fun getClaimablePartitionAssignments(): Set<PartitionAssignment> =
+        partitionAssignments
+            .filter { assignment ->
+                assignment.isClaimable(now) ||
+                    (assignment.leaseExpiresAt == null && assignment.instanceId !in activeInstanceIds)
+            }.toSet()
 
     /**
      * Returns all partition numbers that are currently unassigned (instanceId == null).
@@ -81,13 +93,27 @@ data class PartitionContext(
      *
      * @return Set of partition assignments to release
      */
+    fun getPartitionAssignmentsToStartDraining(): Set<PartitionAssignment> {
+        val count = max(0, countOwnedPartitionAssignments() - targetPartitionCount - countOwnedDrainingPartitionAssignments())
+        if (count == 0) return emptySet()
+
+        return getOwnedPartitionAssignments()
+            .filterNot { it.draining }
+            .sortedBy { it.partitionNumber }
+            .takeLast(count)
+            .toSet()
+    }
+
+    /**
+     * Returns owned draining partitions that can be fully released once in-flight work is done.
+     */
     fun getPartitionAssignmentsToRelease(): Set<PartitionAssignment> {
         val count = countPartitionsToRelease()
         if (count == 0) return emptySet()
 
         return getOwnedPartitionAssignments()
+            .filter { it.draining }
             .sortedBy { it.partitionNumber }
-            .takeLast(count)
             .toSet()
     }
 
@@ -107,12 +133,12 @@ data class PartitionContext(
         val partitionsToClaimCount = countPartitionsToClaim()
         if (partitionsToClaimCount == 0) return emptySet()
 
-        val stalePartitionAssignments = getStalePartitionAssignments()
-        if (stalePartitionAssignments.isEmpty()) return emptySet()
+        val claimableAssignments = getClaimablePartitionAssignments()
+        if (claimableAssignments.isEmpty()) return emptySet()
 
-        if (partitionsToClaimCount > stalePartitionAssignments.size) return emptySet()
+        if (partitionsToClaimCount > claimableAssignments.size) return emptySet()
 
-        return stalePartitionAssignments
+        return claimableAssignments
             .sortedBy { it.partitionNumber }
             .take(partitionsToClaimCount)
             .toSet()

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionCoordinator.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionCoordinator.kt
@@ -1,12 +1,15 @@
 package io.namastack.outbox.partition
 
 import io.namastack.outbox.OpenForProxy
+import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.instance.OutboxInstanceRegistry
 import io.namastack.outbox.partition.PartitionHasher.TOTAL_PARTITIONS
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.scheduling.annotation.Scheduled
 import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Central orchestrator for partition ownership management.
@@ -29,10 +32,13 @@ class PartitionCoordinator(
     private val instanceRegistry: OutboxInstanceRegistry,
     private val partitionAssignmentRepository: PartitionAssignmentRepository,
     private val partitionAssignmentCache: PartitionAssignmentCache,
+    private val partitionDrainTracker: PartitionDrainTracker = PartitionDrainTracker(),
+    private val properties: OutboxProperties = OutboxProperties(),
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(PartitionCoordinator::class.java)
     private val currentInstanceId by lazy { instanceRegistry.getCurrentInstanceId() }
+    private val leaseDuration = Duration.ofSeconds(properties.partition.leaseDurationSeconds)
 
     /**
      * Return currently owned partition numbers (cached until next rebalance).
@@ -65,7 +71,9 @@ class PartitionCoordinator(
                 return
             }
 
+            renewOwnedLeases(partitionContext)
             claimStalePartitions(partitionContext)
+            startDrainingSurplusPartitions(partitionContext)
             releaseSurplusPartitions(partitionContext)
         } finally {
             partitionAssignmentCache.evictAll()
@@ -88,6 +96,7 @@ class PartitionCoordinator(
             currentInstanceId = currentInstanceId,
             activeInstanceIds = activeInstanceIds,
             partitionAssignments = partitionAssignments,
+            now = Instant.now(clock),
         )
     }
 
@@ -132,6 +141,7 @@ class PartitionCoordinator(
                     partitionNumber = partitionNumber,
                     instanceId = currentInstanceId,
                     clock = clock,
+                    leaseDuration = leaseDuration,
                     version = null,
                 )
             }.toSet()
@@ -141,12 +151,27 @@ class PartitionCoordinator(
      * Only partitions that are not assigned to any active instance are considered.
      * Updates ownership to the current instance.
      */
+    private fun renewOwnedLeases(partitionContext: PartitionContext) {
+        val ownedAssignments = partitionContext.getOwnedPartitionAssignments()
+        if (ownedAssignments.isEmpty()) return
+
+        ownedAssignments.forEach { partitionAssignment ->
+            partitionAssignment.renewLease(currentInstanceId, clock, leaseDuration)
+        }
+
+        try {
+            partitionAssignmentRepository.saveAll(ownedAssignments)
+        } catch (_: Exception) {
+            log.debug("Could not renew partition leases for instance {}", currentInstanceId)
+        }
+    }
+
     private fun claimStalePartitions(partitionContext: PartitionContext) {
         val partitionsToClaim = partitionContext.getPartitionAssignmentsToClaim()
         if (partitionsToClaim.isEmpty()) return
 
         partitionsToClaim.forEach { partitionAssignment ->
-            partitionAssignment.claim(currentInstanceId, clock)
+            partitionAssignment.claim(currentInstanceId, clock, leaseDuration)
         }
 
         val partitionNumbersToClaim = partitionsToClaim.map { it.partitionNumber }
@@ -172,11 +197,48 @@ class PartitionCoordinator(
     }
 
     /**
-     * Releases surplus partitions owned by the current instance to achieve a balanced distribution.
-     * Only partitions assigned to this instance are considered for release.
+     * Marks surplus partitions as draining so the owner stops taking new work.
+     */
+    private fun startDrainingSurplusPartitions(partitionContext: PartitionContext) {
+        val partitionsToDrain = partitionContext.getPartitionAssignmentsToStartDraining()
+        if (partitionsToDrain.isEmpty()) return
+
+        partitionsToDrain.forEach { partitionAssignment ->
+            partitionAssignment.markDraining(currentInstanceId, clock, leaseDuration)
+        }
+
+        val partitionNumbersToDrain = partitionsToDrain.map { it.partitionNumber }
+
+        try {
+            partitionAssignmentRepository.saveAll(partitionsToDrain)
+        } catch (_: Exception) {
+            log.debug(
+                "Could not mark partitions {} as draining for instance {}",
+                partitionNumbersToDrain,
+                currentInstanceId,
+            )
+            return
+        }
+
+        log.debug(
+            "Successfully marked {} partitions as draining for instance {}: {}",
+            partitionsToDrain.size,
+            currentInstanceId,
+            partitionNumbersToDrain,
+        )
+    }
+
+    /**
+     * Releases draining partitions once the current instance has no local work in flight for them.
      */
     private fun releaseSurplusPartitions(partitionContext: PartitionContext) {
-        val partitionsToRelease = partitionContext.getPartitionAssignmentsToRelease()
+        val releaseCandidates = partitionContext.getPartitionAssignmentsToRelease()
+        if (releaseCandidates.isEmpty()) return
+
+        val partitionsToRelease =
+            releaseCandidates.filterNot { assignment ->
+                partitionDrainTracker.hasInFlightRecords(setOf(assignment.partitionNumber))
+            }.toSet()
         if (partitionsToRelease.isEmpty()) return
 
         partitionsToRelease.forEach { partitionAssignment ->

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionDrainTracker.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionDrainTracker.kt
@@ -1,0 +1,33 @@
+package io.namastack.outbox.partition
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tracks in-flight processing per partition so draining partitions can be
+ * released only after local work finishes.
+ */
+class PartitionDrainTracker {
+    private val inFlightByPartition = ConcurrentHashMap<Int, AtomicInteger>()
+
+    fun start(partitionNumber: Int) {
+        inFlightByPartition.compute(partitionNumber) { _, current ->
+            (current ?: AtomicInteger()).apply { incrementAndGet() }
+        }
+    }
+
+    fun finish(partitionNumber: Int) {
+        inFlightByPartition.computeIfPresent(partitionNumber) { _, current ->
+            if (current.decrementAndGet() <= 0) {
+                null
+            } else {
+                current
+            }
+        }
+    }
+
+    fun hasInFlightRecords(partitionNumbers: Set<Int>): Boolean =
+        partitionNumbers.any { partitionNumber ->
+            inFlightByPartition[partitionNumber]?.get()?.let { it > 0 } == true
+        }
+}

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/partition/PartitionContextTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/partition/PartitionContextTest.kt
@@ -68,18 +68,18 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getStalePartitionAssignments returns assignments from inactive instances`() {
+    fun `getClaimablePartitionAssignments returns expired assignments from inactive instances`() {
         val assignments =
             setOf(
                 PartitionAssignment.create(0, "i-1", clock, null),
-                PartitionAssignment.create(1, "i-old", clock, null),
+                PartitionAssignment(1, "i-old", Instant.now(clock), leaseExpiresAt = null),
                 PartitionAssignment.create(2, "i-2", clock, null),
-                PartitionAssignment.create(3, "i-gone", clock, null),
+                PartitionAssignment(3, "i-gone", Instant.now(clock), leaseExpiresAt = null),
             )
         val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), assignments)
-        val stale = ctx.getStalePartitionAssignments().map { it.partitionNumber }.sorted()
+        val claimable = ctx.getClaimablePartitionAssignments().map { it.partitionNumber }.sorted()
 
-        assertThat(stale).containsExactly(1, 3)
+        assertThat(claimable).containsExactly(1, 3)
     }
 
     @Test
@@ -168,7 +168,7 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getPartitionAssignmentsToRelease returns empty when no surplus`() {
+    fun `getPartitionAssignmentsToRelease returns empty when no draining partitions exist`() {
         val assignments = (0..127).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
         val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), assignments)
 
@@ -176,15 +176,33 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getPartitionAssignmentsToRelease returns last N assignments to release`() {
+    fun `getPartitionAssignmentsToStartDraining returns last N assignments to release`() {
         val i1Partitions = (0..149).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
         val i2Partitions = (150..255).map { PartitionAssignment.create(it, "i-2", clock, null) }.toSet()
         val assignments = i1Partitions + i2Partitions
 
         val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), assignments)
-        val toRelease = ctx.getPartitionAssignmentsToRelease()
+        val toRelease = ctx.getPartitionAssignmentsToStartDraining()
 
         assertThat(toRelease.map { it.partitionNumber }).containsExactlyInAnyOrder(*(128..149).toList().toTypedArray())
+    }
+
+    @Test
+    fun `getPartitionAssignmentsToRelease returns owned draining partitions`() {
+        val i1NonDraining = (0..127).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
+        val i1Draining =
+            (128..149)
+                .map { partitionNumber ->
+                    PartitionAssignment.create(partitionNumber, "i-1", clock, null).apply {
+                        markDraining("i-1", clock, java.time.Duration.ofSeconds(30))
+                    }
+                }.toSet()
+        val i2Partitions = (150..255).map { PartitionAssignment.create(it, "i-2", clock, null) }.toSet()
+
+        val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), i1NonDraining + i1Draining + i2Partitions)
+
+        assertThat(ctx.getPartitionAssignmentsToRelease().map { it.partitionNumber })
+            .containsExactlyInAnyOrder(*(128..149).toList().toTypedArray())
     }
 
     @Test
@@ -196,7 +214,7 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getPartitionAssignmentsToClaim returns empty when no stale partitions`() {
+    fun `getPartitionAssignmentsToClaim returns empty when no claimable partitions`() {
         val i1Partitions = (0..9).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
         val i2Partitions = (10..255).map { PartitionAssignment.create(it, "i-2", clock, null) }.toSet()
         val assignments = i1Partitions + i2Partitions
@@ -207,10 +225,13 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getPartitionAssignmentsToClaim returns empty when insufficient stale partitions`() {
+    fun `getPartitionAssignmentsToClaim returns empty when insufficient claimable partitions`() {
         val i1Partitions = (0..55).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
         val i2Partitions = (56..155).map { PartitionAssignment.create(it, "i-2", clock, null) }.toSet()
-        val stalePartitions = (156..205).map { PartitionAssignment.create(it, "i-old", clock, null) }.toSet()
+        val stalePartitions =
+            (156..205)
+                .map { PartitionAssignment(it, "i-old", Instant.now(clock), leaseExpiresAt = null) }
+                .toSet()
         val assignments = i1Partitions + i2Partitions + stalePartitions
 
         val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), assignments)
@@ -219,10 +240,13 @@ class PartitionContextTest {
     }
 
     @Test
-    fun `getPartitionAssignmentsToClaim returns first N stale assignments`() {
+    fun `getPartitionAssignmentsToClaim returns first N claimable assignments`() {
         val i1Partitions = (0..99).map { PartitionAssignment.create(it, "i-1", clock, null) }.toSet()
         val i2Partitions = (100..127).map { PartitionAssignment.create(it, "i-2", clock, null) }.toSet()
-        val stalePartitions = (128..177).map { PartitionAssignment.create(it, "i-old", clock, null) }.toSet()
+        val stalePartitions =
+            (128..177)
+                .map { PartitionAssignment(it, "i-old", Instant.now(clock), leaseExpiresAt = null) }
+                .toSet()
         val assignments = i1Partitions + i2Partitions + stalePartitions
 
         val ctx = PartitionContext("i-1", setOf("i-1", "i-2"), assignments)

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/partition/PartitionCoordinatorTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/partition/PartitionCoordinatorTest.kt
@@ -152,7 +152,7 @@ class PartitionCoordinatorTest {
 
             partitionCoordinator.rebalance()
 
-            verify(exactly = 1) { partitionAssignmentRepository.saveAll(any()) }
+            verify(atLeast = 1) { partitionAssignmentRepository.saveAll(any()) }
         }
 
         @Test
@@ -206,7 +206,7 @@ class PartitionCoordinatorTest {
 
             partitionCoordinator.rebalance()
 
-            verify(exactly = 1) { partitionAssignmentRepository.saveAll(any()) }
+            verify(atLeast = 1) { partitionAssignmentRepository.saveAll(any()) }
         }
 
         @Test
@@ -224,7 +224,7 @@ class PartitionCoordinatorTest {
 
             partitionCoordinator.rebalance()
 
-            verify(exactly = 1) { partitionAssignmentRepository.saveAll(any()) }
+            verify(atLeast = 1) { partitionAssignmentRepository.saveAll(any()) }
         }
 
         @Test

--- a/namastack-outbox-docs/docs/reference/configuration.md
+++ b/namastack-outbox-docs/docs/reference/configuration.md
@@ -46,6 +46,8 @@ namastack:
       stale-instance-timeout-seconds: 30       # When an instance is considered stale and removed (default: 30)
       heartbeat-interval-seconds: 5            # How often each instance sends a heartbeat (default: 5)
       rebalance-interval: 10000                # How often partitions are recalculated (default: 10000)
+    partition:
+      lease-duration-seconds: 30               # Partition ownership lease TTL (default: 30)
 
     jdbc:
       table-prefix: ""                         # Prefix for table names (default: empty)
@@ -110,6 +112,23 @@ namastack:
   outbox:
     enabled: false
 ```
+
+---
+
+## Partition Lease
+
+Partition ownership is lease-based. Each owner periodically renews its lease and partitions become claimable when the lease expires.
+
+```yaml
+namastack:
+  outbox:
+    partition:
+      lease-duration-seconds: 30
+```
+
+- Lower values speed up failover after a crash but increase sensitivity to short pauses.
+- Higher values reduce churn but can delay failover.
+- During rebalance, surplus partitions are first marked as draining and released after in-flight local work completes.
 
 This prevents all outbox beans from being created, useful for:
 

--- a/namastack-outbox-docs/docs/reference/core.md
+++ b/namastack-outbox-docs/docs/reference/core.md
@@ -163,7 +163,15 @@ namastack:
       stale-instance-timeout-seconds: 30       # When an instance is considered stale and removed
       graceful-shutdown-timeout-seconds: 0     # Optional: propagation window on shutdown (default: 0)
       rebalance-interval: 10000                # How often partitions are recalculated
+    partition:
+      lease-duration-seconds: 30               # How long partition ownership remains valid without renewal
 ```
+
+### Lease-based Ownership and Draining
+
+Partition ownership uses leases. Active owners renew leases on each rebalance cycle. If an owner stops renewing, the lease expires and other active instances can claim the partition.
+
+To avoid abrupt handoff, surplus partitions are first marked as draining. Draining partitions stop accepting new work on the current instance and are only released after local in-flight processing completes.
 
 <Tabs>
 <TabItem value="3instances" label="3 Instances">

--- a/namastack-outbox-examples/namastack-outbox-example-flyway-jdbc/src/main/resources/db/migration/V3__add_partition_lease_columns.sql
+++ b/namastack-outbox-examples/namastack-outbox-example-flyway-jdbc/src/main/resources/db/migration/V3__add_partition_lease_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE outbox_partition
+    ADD COLUMN lease_expires_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE outbox_partition
+    ADD COLUMN draining BOOLEAN NOT NULL DEFAULT FALSE;

--- a/namastack-outbox-examples/namastack-outbox-example-flyway-jpa/src/main/resources/db/migration/V3__add_partition_lease_columns.sql
+++ b/namastack-outbox-examples/namastack-outbox-example-flyway-jpa/src/main/resources/db/migration/V3__add_partition_lease_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE outbox_partition
+    ADD COLUMN lease_expires_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE outbox_partition
+    ADD COLUMN draining BOOLEAN NOT NULL DEFAULT FALSE;

--- a/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
+++ b/namastack-outbox-integration-tests/src/test/kotlin/io/namastack/outbox/PartitioningIntegrationTest.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Clock
+import java.time.Instant
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit.SECONDS
@@ -97,6 +98,12 @@ class PartitioningIntegrationTest {
 
         // remove bootstrap instance so all its partitions become stale
         instanceRepository.deleteById(instanceId1)
+        val expiredAssignments =
+            partitionAssignmentRepository.findAll().map { assignment ->
+                assignment.leaseExpiresAt = Instant.now(clock).minusSeconds(1)
+                assignment
+            }.toSet()
+        partitionAssignmentRepository.saveAll(expiredAssignments)
 
         val instanceId2 = "instance-2"
         val instanceId3 = "instance-3"

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentEntity.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentEntity.kt
@@ -16,4 +16,6 @@ internal data class JdbcOutboxPartitionAssignmentEntity(
     val instanceId: String?,
     val version: Long?,
     val updatedAt: Instant,
+    val leaseExpiresAt: Instant? = null,
+    val draining: Boolean = false,
 )

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentEntityMapper.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentEntityMapper.kt
@@ -18,6 +18,8 @@ internal object JdbcOutboxPartitionAssignmentEntityMapper {
             instanceId = partition.instanceId,
             version = partition.version,
             updatedAt = partition.updatedAt,
+            leaseExpiresAt = partition.leaseExpiresAt,
+            draining = partition.draining,
         )
 
     /**
@@ -29,5 +31,7 @@ internal object JdbcOutboxPartitionAssignmentEntityMapper {
             instanceId = entity.instanceId,
             version = entity.version,
             updatedAt = entity.updatedAt,
+            leaseExpiresAt = entity.leaseExpiresAt,
+            draining = entity.draining,
         )
 }

--- a/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
+++ b/namastack-outbox-jdbc/src/main/kotlin/io/namastack/outbox/JdbcOutboxPartitionAssignmentRepository.kt
@@ -54,7 +54,8 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
     private val updatePartitionQuery =
         """
         UPDATE $tableName
-        SET instance_id = :instanceId, version = :version, updated_at = :updatedAt
+        SET instance_id = :instanceId, version = :version, updated_at = :updatedAt,
+            lease_expires_at = :leaseExpiresAt, draining = :draining
         WHERE partition_number = :partitionNumber AND version = :originalVersion
         """.toSingleLine()
 
@@ -72,8 +73,8 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
      */
     private val insertPartitionQuery =
         """
-        INSERT INTO $tableName (partition_number, instance_id, version, updated_at)
-        VALUES (:partitionNumber, :instanceId, :version, :updatedAt)
+        INSERT INTO $tableName (partition_number, instance_id, version, updated_at, lease_expires_at, draining)
+        VALUES (:partitionNumber, :instanceId, :version, :updatedAt, :leaseExpiresAt, :draining)
         """.toSingleLine()
 
     /**
@@ -144,6 +145,8 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
             .param("instanceId", entity.instanceId)
             .param("version", newVersion)
             .param("updatedAt", Timestamp.from(entity.updatedAt))
+            .param("leaseExpiresAt", entity.leaseExpiresAt?.let { Timestamp.from(it) })
+            .param("draining", entity.draining)
             .param("partitionNumber", entity.partitionNumber)
             .param("originalVersion", originalVersion ?: 0)
             .update()
@@ -182,6 +185,8 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
             .param("instanceId", entity.instanceId)
             .param("version", 0) // Initial version is 0
             .param("updatedAt", Timestamp.from(entity.updatedAt))
+            .param("leaseExpiresAt", entity.leaseExpiresAt?.let { Timestamp.from(it) })
+            .param("draining", entity.draining)
             .update()
     }
 
@@ -195,6 +200,8 @@ internal open class JdbcOutboxPartitionAssignmentRepository(
                 instanceId = rs.getString("instance_id"),
                 version = rs.getLong("version"),
                 updatedAt = rs.getTimestamp("updated_at").toInstant(),
+                leaseExpiresAt = rs.getTimestamp("lease_expires_at")?.toInstant(),
+                draining = rs.getBoolean("draining"),
             )
     }
 }

--- a/namastack-outbox-jdbc/src/main/resources/schema/h2/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/h2/outbox-tables.sql
@@ -33,7 +33,9 @@ CREATE TABLE IF NOT EXISTS outbox_partition
     partition_number INTEGER PRIMARY KEY,
     instance_id      VARCHAR(255),
     version          BIGINT                   NOT NULL DEFAULT 0,
-    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL,
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    draining         BOOLEAN                  NOT NULL DEFAULT FALSE
 );
 
 CREATE INDEX IF NOT EXISTS idx_outbox_record_record_key_created

--- a/namastack-outbox-jdbc/src/main/resources/schema/mariadb/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/mariadb/outbox-tables.sql
@@ -42,7 +42,8 @@ CREATE TABLE IF NOT EXISTS outbox_partition
     instance_id      VARCHAR(255),
     version          BIGINT    NOT NULL DEFAULT 0,
     updated_at       TIMESTAMP NOT NULL,
+    lease_expires_at TIMESTAMP NULL,
+    draining         BOOLEAN   NOT NULL DEFAULT FALSE,
     INDEX idx_outbox_partition_instance_id (instance_id)
 ) ENGINE = InnoDB;
-
 

--- a/namastack-outbox-jdbc/src/main/resources/schema/mysql/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/mysql/outbox-tables.sql
@@ -42,5 +42,7 @@ CREATE TABLE IF NOT EXISTS outbox_partition
     instance_id      VARCHAR(255),
     version          BIGINT    NOT NULL DEFAULT 0,
     updated_at       TIMESTAMP NOT NULL,
+    lease_expires_at TIMESTAMP NULL,
+    draining         BOOLEAN   NOT NULL DEFAULT FALSE,
     INDEX idx_outbox_partition_instance_id (instance_id)
 ) ENGINE = InnoDB;

--- a/namastack-outbox-jdbc/src/main/resources/schema/oracle/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/oracle/outbox-tables.sql
@@ -68,10 +68,11 @@ BEGIN
                 partition_number NUMBER(10) PRIMARY KEY,
                 instance_id      VARCHAR2(255),
                 version          NUMBER(19) DEFAULT 0 NOT NULL,
-                updated_at       TIMESTAMP WITH TIME ZONE NOT NULL
+                updated_at       TIMESTAMP WITH TIME ZONE NOT NULL,
+                lease_expires_at TIMESTAMP WITH TIME ZONE,
+                draining         NUMBER(1) DEFAULT 0 NOT NULL
             )';
         EXECUTE IMMEDIATE 'CREATE INDEX idx_outbox_part_inst_id ON outbox_partition (instance_id)';
     END IF;
 END;
 /
-

--- a/namastack-outbox-jdbc/src/main/resources/schema/postgres/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/postgres/outbox-tables.sql
@@ -33,7 +33,9 @@ CREATE TABLE IF NOT EXISTS outbox_partition
     partition_number INTEGER PRIMARY KEY,
     instance_id      VARCHAR(255),
     version          BIGINT                   NOT NULL DEFAULT 0,
-    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL,
+    lease_expires_at TIMESTAMP WITH TIME ZONE,
+    draining         BOOLEAN                  NOT NULL DEFAULT FALSE
 );
 
 CREATE INDEX IF NOT EXISTS idx_outbox_record_record_key_created

--- a/namastack-outbox-jdbc/src/main/resources/schema/sqlserver/outbox-tables.sql
+++ b/namastack-outbox-jdbc/src/main/resources/schema/sqlserver/outbox-tables.sql
@@ -51,7 +51,9 @@ CREATE TABLE outbox_partition
     partition_number INT          NOT NULL,
     instance_id      VARCHAR(255),
     version          BIGINT       NOT NULL DEFAULT 0,
-    updated_at       DATETIME2(6) NOT NULL
+    updated_at       DATETIME2(6) NOT NULL,
+    lease_expires_at DATETIME2(6) NULL,
+    draining         BIT          NOT NULL DEFAULT 0,
         PRIMARY KEY (partition_number),
     INDEX idx_outbox_partition_instance_id (instance_id)
 );

--- a/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/OutboxPartitionAssignmentEntity.kt
+++ b/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/OutboxPartitionAssignmentEntity.kt
@@ -38,4 +38,8 @@ internal data class OutboxPartitionAssignmentEntity(
     val version: Long? = null,
     @Column(name = "updated_at", nullable = false)
     var updatedAt: Instant,
+    @Column(name = "lease_expires_at")
+    var leaseExpiresAt: Instant? = null,
+    @Column(name = "draining", nullable = false)
+    var draining: Boolean = false,
 )

--- a/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/OutboxPartitionAssignmentEntityMapper.kt
+++ b/namastack-outbox-jpa/src/main/kotlin/io/namastack/outbox/OutboxPartitionAssignmentEntityMapper.kt
@@ -17,6 +17,8 @@ internal object OutboxPartitionAssignmentEntityMapper {
             partitionNumber = partition.partitionNumber,
             instanceId = partition.instanceId,
             updatedAt = partition.updatedAt,
+            leaseExpiresAt = partition.leaseExpiresAt,
+            draining = partition.draining,
             version = partition.version,
         )
 
@@ -28,6 +30,8 @@ internal object OutboxPartitionAssignmentEntityMapper {
             partitionNumber = entity.partitionNumber,
             instanceId = entity.instanceId,
             updatedAt = entity.updatedAt,
+            leaseExpiresAt = entity.leaseExpiresAt,
+            draining = entity.draining,
             version = entity.version,
         )
 

--- a/namastack-outbox-mongodb/src/main/kotlin/io/namastack/outbox/MongoOutboxPartitionAssignmentEntity.kt
+++ b/namastack-outbox-mongodb/src/main/kotlin/io/namastack/outbox/MongoOutboxPartitionAssignmentEntity.kt
@@ -21,4 +21,6 @@ internal data class MongoOutboxPartitionAssignmentEntity(
     @Version
     val version: Long? = null,
     val updatedAt: Instant,
+    val leaseExpiresAt: Instant? = null,
+    val draining: Boolean = false,
 )

--- a/namastack-outbox-mongodb/src/main/kotlin/io/namastack/outbox/MongoOutboxPartitionAssignmentEntityMapper.kt
+++ b/namastack-outbox-mongodb/src/main/kotlin/io/namastack/outbox/MongoOutboxPartitionAssignmentEntityMapper.kt
@@ -21,6 +21,8 @@ internal object MongoOutboxPartitionAssignmentEntityMapper {
             instanceId = assignment.instanceId,
             version = assignment.version,
             updatedAt = assignment.updatedAt,
+            leaseExpiresAt = assignment.leaseExpiresAt,
+            draining = assignment.draining,
         )
 
     /**
@@ -35,5 +37,7 @@ internal object MongoOutboxPartitionAssignmentEntityMapper {
             instanceId = entity.instanceId,
             version = entity.version,
             updatedAt = entity.updatedAt,
+            leaseExpiresAt = entity.leaseExpiresAt,
+            draining = entity.draining,
         )
 }


### PR DESCRIPTION
## Summary
- add lease-based partition ownership with renewal/expiry and claimable-processable semantics
- introduce draining-aware rebalance using in-flight tracking to release partitions only after local work completes
- persist new partition fields across JDBC/JPA/Mongo, update SQL schemas, and add additive Flyway `V3` migrations in examples
- document `namastack.outbox.partition.lease-duration-seconds` and lease/draining behavior

## Why
In autoscaling/container environments (for example AWS Fargate), frequent instance churn can leave partition ownership stale or handoff abrupt. Lease-based ownership provides bounded failover, and draining improves handoff safety by waiting for local in-flight work to finish before release.

## Breaking change
- database migration is required before upgrade (`outbox_partition.lease_expires_at`, `outbox_partition.draining`); treat this as a major-version change

## Test plan
- [x] existing core unit/integration tests updated for claimable/draining semantics
- [ ] run full CI matrix for JDBC/JPA/Mongo modules
- [ ] validate Flyway upgrade path from `V1`+`V2` to `V3` in example apps