### PR TITLE
Include cause in log when failed to bootstrap partitions

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionCoordinator.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/partition/PartitionCoordinator.kt
@@ -111,7 +111,7 @@ class PartitionCoordinator(
             )
             return
         } catch (e: Exception) {
-            log.error("Failed to bootstrap partitions for instance {}: {}", currentInstanceId, e.message)
+            log.error("Failed to bootstrap partitions for instance {}: {}", currentInstanceId, e.message, e)
             return
         }
 


### PR DESCRIPTION
We have a MongoDB database and get an error in our logs:
```
Failed to bootstrap partitions for instance de1808e0-d789-430b-9d80-2853cf6e2c75: Could not commit Mongo transaction for session
```

I would like the cause exception logged so it is easier to debug this. 