### PR TITLE
Allow package-private annotated methods

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/internal/ReflectionUtils.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/internal/ReflectionUtils.kt
@@ -1,6 +1,7 @@
 package io.namastack.outbox.handler.method.internal
 
 import org.springframework.aop.support.AopUtils
+import org.springframework.core.MethodIntrospector
 import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.Method
 
@@ -52,10 +53,14 @@ internal object ReflectionUtils {
         parameterCount: Int,
     ): Method {
         val method =
-            getTargetClass(bean)
-                .methods
-                .filter { !it.isBridge && !it.isSynthetic }
-                .first { it.name == methodName && it.parameterCount == parameterCount }
+            MethodIntrospector
+                .selectMethods(
+                    getTargetClass(bean),
+                    MethodIntrospector.MetadataLookup { method ->
+                        method.takeIf { it.name == methodName && it.parameterCount == parameterCount }
+                    },
+                ).keys
+                .first()
 
         method.trySetAccessible()
 
@@ -81,12 +86,14 @@ internal object ReflectionUtils {
     fun <A : Annotation> findAnnotatedMethods(
         bean: Any,
         annotationClass: Class<A>,
-    ): Sequence<Method> {
-        val targetClass = getTargetClass(bean)
-        return targetClass.methods
+    ): Sequence<Method> =
+        MethodIntrospector
+            .selectMethods(
+                getTargetClass(bean),
+                MethodIntrospector.MetadataLookup { method ->
+                    AnnotatedElementUtils.findMergedAnnotation(method, annotationClass)
+                },
+            ).keys
             .asSequence()
-            .filterNot { it.isBridge && it.isSynthetic }
-            .filter { AnnotatedElementUtils.findMergedAnnotation(it, annotationClass) != null }
             .onEach { it.trySetAccessible() }
-    }
 }

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandler.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandler.java
@@ -1,0 +1,12 @@
+package io.namastack.outbox;
+
+import io.namastack.outbox.annotation.OutboxHandler;
+import io.namastack.outbox.handler.OutboxRecordMetadata;
+
+@SuppressWarnings("unused")
+public class JavaPackagePrivateAnnotatedHandler {
+
+    @OutboxHandler
+    void handle(String payload, OutboxRecordMetadata metadata) {
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandlerWithFallback.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandlerWithFallback.java
@@ -1,0 +1,18 @@
+package io.namastack.outbox;
+
+import io.namastack.outbox.annotation.OutboxFallbackHandler;
+import io.namastack.outbox.annotation.OutboxHandler;
+import io.namastack.outbox.handler.OutboxFailureContext;
+import io.namastack.outbox.handler.OutboxRecordMetadata;
+
+@SuppressWarnings("unused")
+public class JavaPackagePrivateAnnotatedHandlerWithFallback {
+
+    @OutboxHandler
+    void handle(String payload, OutboxRecordMetadata metadata) {
+    }
+
+    @OutboxFallbackHandler
+    void handleFailure(String payload, OutboxFailureContext context) {
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandlerWithRetryable.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/JavaPackagePrivateAnnotatedHandlerWithRetryable.java
@@ -1,0 +1,14 @@
+package io.namastack.outbox;
+
+import io.namastack.outbox.annotation.OutboxHandler;
+import io.namastack.outbox.annotation.OutboxRetryable;
+import io.namastack.outbox.handler.OutboxRecordMetadata;
+
+@SuppressWarnings("unused")
+public class JavaPackagePrivateAnnotatedHandlerWithRetryable {
+
+    @OutboxHandler
+    @OutboxRetryable(name = "CustomerOutboxRetryPolicy")
+    void handle(String payload, OutboxRecordMetadata metadata) {
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/method/internal/JavaPackagePrivateAnnotatedBean.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/method/internal/JavaPackagePrivateAnnotatedBean.java
@@ -1,0 +1,16 @@
+package io.namastack.outbox.handler.method.internal;
+
+@SuppressWarnings("unused")
+public class JavaPackagePrivateAnnotatedBean {
+
+    @TestJavaAnnotation("java-method-1")
+    void annotatedMethod1(String param) {
+    }
+
+    @TestJavaAnnotation("java-method-2")
+    void annotatedMethod2(String param) {
+    }
+
+    void nonAnnotatedMethod() {
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/method/internal/TestJavaAnnotation.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/method/internal/TestJavaAnnotation.java
@@ -1,0 +1,12 @@
+package io.namastack.outbox.handler.method.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestJavaAnnotation {
+    String value() default "";
+}

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/HandlerBeanFactory.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/HandlerBeanFactory.kt
@@ -75,6 +75,15 @@ object HandlerBeanFactory {
 
     fun createMultipleAnnotatedTypedHandlersWithMultipleFallbacks(): MultipleAnnotatedTypedHandlersWithMultipleFallbacks =
         MultipleAnnotatedTypedHandlersWithMultipleFallbacks()
+
+    fun createJavaPackagePrivateAnnotatedHandler(): JavaPackagePrivateAnnotatedHandler =
+        JavaPackagePrivateAnnotatedHandler()
+
+    fun createJavaPackagePrivateAnnotatedHandlerWithFallback(): JavaPackagePrivateAnnotatedHandlerWithFallback =
+        JavaPackagePrivateAnnotatedHandlerWithFallback()
+
+    fun createJavaPackagePrivateAnnotatedHandlerWithRetryable(): JavaPackagePrivateAnnotatedHandlerWithRetryable =
+        JavaPackagePrivateAnnotatedHandlerWithRetryable()
 }
 
 class GenericInterfaceHandler : io.namastack.outbox.handler.OutboxHandler {

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
@@ -99,6 +99,38 @@ class OutboxHandlerBeanPostProcessorTest {
     }
 
     @Test
+    fun `registers handler when package-private method annotated with @OutboxHandler`() {
+        val bean = HandlerBeanFactory.createJavaPackagePrivateAnnotatedHandler()
+        beanPostProcessor.postProcessAfterInitialization(bean, "bean")
+
+        verify(exactly = 1) { handlerRegistry.register(any()) }
+        verify(exactly = 0) { fallbackHandlerRegistry.register(any(), any()) }
+        verify(exactly = 0) { retryPolicyRegistry.register(any(), any()) }
+    }
+
+    @Test
+    fun `registers handler with fallback when package-private @OutboxHandler and @OutboxFallbackHandler methods`() {
+        val bean = HandlerBeanFactory.createJavaPackagePrivateAnnotatedHandlerWithFallback()
+        beanPostProcessor.postProcessAfterInitialization(bean, "bean")
+
+        verify(exactly = 1) { handlerRegistry.register(any()) }
+        verify(exactly = 1) { fallbackHandlerRegistry.register(any(), any()) }
+        verify(exactly = 0) { retryPolicyRegistry.register(any(), any()) }
+    }
+
+    @Test
+    fun `registers handler with retry policy when package-private @OutboxHandler and @OutboxRetryable method`() {
+        every { retryPolicyRegistry.getRetryPolicy(any<String>()) } returns CustomerOutboxRetryPolicy()
+
+        val bean = HandlerBeanFactory.createJavaPackagePrivateAnnotatedHandlerWithRetryable()
+        beanPostProcessor.postProcessAfterInitialization(bean, "bean")
+
+        verify(exactly = 1) { handlerRegistry.register(any()) }
+        verify(exactly = 0) { fallbackHandlerRegistry.register(any(), any()) }
+        verify(exactly = 1) { retryPolicyRegistry.register(any(), any()) }
+    }
+
+    @Test
     fun `registers multiple handlers from same bean`() {
         val bean = HandlerBeanFactory.createMultiAnnotatedHandlerBean()
         beanPostProcessor.postProcessAfterInitialization(bean, "bean")

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/internal/ReflectionUtilsTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/internal/ReflectionUtilsTest.kt
@@ -177,6 +177,16 @@ class ReflectionUtilsTest {
         assertThat(method.canAccess(bean) || method.isAccessible).isTrue()
     }
 
+    @Test
+    fun `findAnnotatedMethods finds all Java package-private methods`() {
+        val bean = JavaPackagePrivateAnnotatedBean()
+
+        val result = ReflectionUtils.findAnnotatedMethods(bean, TestJavaAnnotation::class.java).toList()
+
+        assertThat(result).hasSize(2)
+        assertThat(result.map { it.name }).containsExactlyInAnyOrder("annotatedMethod1", "annotatedMethod2")
+    }
+
     // Test beans
     @Suppress("UNUSED_PARAMETER")
     open class TestBean {


### PR DESCRIPTION
Annotations such as `@KafkaListener`, `@RabbitListener`, etc. from Spring itself are applied on a method even if it's `package-private`. Right now, this library requires all methods annotated with `@OutboxHandler` to be `public`, due to using Java's native `Class.getMethods()` instead of Spring's `MethodIntrospector`. I propose to keep it the same way, to avoid confusion and improve Java interop of this library.

I know that as in `CONTRIBUTING.md`, the project is 100% Kotlin, but I had to add Java classes in test sources to properly test package-private methods.