### PR TITLE
GH-395 Use outboxHeartbeatScheduler for OutboxInstanceRegistry tasks

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -2,7 +2,6 @@ package io.namastack.outbox.config
 
 import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.Outbox
-import io.namastack.outbox.OutboxProcessingScheduler
 import io.namastack.outbox.OutboxProperties
 import io.namastack.outbox.OutboxRecordRepository
 import io.namastack.outbox.OutboxService
@@ -75,7 +74,7 @@ class OutboxCoreInfrastructureAutoConfiguration {
         beanFactory: BeanFactory,
         observationRegistry: ObjectProvider<ObservationRegistry>,
     ): OutboxInstanceRegistry {
-        val taskScheduler = beanFactory.getBean(OutboxProcessingScheduler.SCHEDULER_NAME) as TaskScheduler
+        val taskScheduler = beanFactory.getBean(OutboxInstanceRegistry.SCHEDULER_NAME) as TaskScheduler
         return OutboxInstanceRegistry(
             instanceRepository,
             properties,

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
@@ -29,10 +29,13 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.SimpleAsyncTaskExecutor
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.TriggerContext
 import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import org.springframework.test.util.ReflectionTestUtils
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -88,6 +91,35 @@ class OutboxCoreAutoConfigurationTest {
                 .withUserConfiguration(MinimalTestConfig::class.java)
                 .run { context ->
                     assertThat(context).hasSingleBean(OutboxInstanceRegistry::class.java)
+                    val instanceRegistry = context.getBean<OutboxInstanceRegistry>()
+
+                    // verify injected scheduler is the same as outboxHeartbeatScheduler
+                    val injectedScheduler =
+                        ReflectionTestUtils.getField(instanceRegistry, "taskScheduler") as TaskScheduler
+                    val heartbeatScheduler = context.getBean("outboxHeartbeatScheduler") as TaskScheduler
+                    assertThat(injectedScheduler).isSameAs(heartbeatScheduler)
+                }
+        }
+
+        @Test
+        fun `creates default processing scheduler`() {
+            contextRunner
+                .withUserConfiguration(MinimalTestConfig::class.java)
+                .run { context ->
+                    assertThat(context).hasSingleBean(OutboxProcessingScheduler::class.java)
+                    val processingScheduler = context.getBean<OutboxProcessingScheduler>()
+
+                    // verify injected scheduler is the same as outboxDefaultScheduler
+                    val injectedScheduler =
+                        ReflectionTestUtils.getField(processingScheduler, "taskScheduler") as TaskScheduler
+                    val heartbeatScheduler = context.getBean("outboxDefaultScheduler") as TaskScheduler
+                    assertThat(injectedScheduler).isSameAs(heartbeatScheduler)
+
+                    // verify injected Executor is the same as outboxTaskExecutor
+                    val injectedExecutor =
+                        ReflectionTestUtils.getField(processingScheduler, "taskExecutor") as TaskExecutor
+                    val outboxTaskExecutor = context.getBean("outboxTaskExecutor") as TaskExecutor
+                    assertThat(injectedExecutor).isSameAs(outboxTaskExecutor)
                 }
         }
     }


### PR DESCRIPTION
## Summary

Fixes GH-395 by scheduling `OutboxInstanceRegistry` heartbeat tasks using `outboxHeartbeatScheduler` instead of `outboxDefaultScheduler`.

## Problem

Heartbeats were being scheduled on the same scheduler used for regular outbox task execution. When a long-running task occupied the scheduler thread, heartbeat updates could be delayed, causing instances to miss heartbeat deadlines and trigger unnecessary re-registration attempts:

> Failed to send heartbeat for instance ... re-registering

## Solution

Update `OutboxInstanceRegistry` to schedule heartbeat tasks using `TaskSchedulerRouter`, ensuring they are executed by the dedicated `outboxHeartbeatScheduler`.

This isolates heartbeat processing from regular task execution and prevents heartbeat starvation caused by long-running tasks.

## Verification

Added tests to verify that heartbeat tasks are scheduled using the dedicated heartbeat scheduler.
