### PR TITLE
GH-420 support stable outbox handler identifiers

### DIFF
--- a/docs/spring-modulith-1777-proposal.md
+++ b/docs/spring-modulith-1777-proposal.md
@@ -35,10 +35,22 @@ void externalize(Object event, OutboxRecordMetadata metadata) {
 }
 ```
 
+Previous identifiers can also be declared explicitly when a handler was renamed:
+
+```java
+@OutboxHandler(
+    id = "spring-modulith-event-externalizer",
+    aliases = { "com.example.PreviousHandler#handle(java.lang.Object)" }
+)
+```
+
 Spring Modulith can implement this interface on its Namastack handler without changing either
 existing `OutboxHandler` implementations or the scheduling API. Namastack continues registering the
 previous generated identifier as a legacy alias, allowing records created before the integration
 adopts the stable identifier to drain normally. New records persist the explicit stable identifier.
+For proxied handlers, both the generated target-class identifier and the historical runtime
+proxy-class identifier are registered as aliases. Configured and automatically generated aliases
+share the same global uniqueness constraint as canonical handler identifiers.
 
 The configured identifier must be non-blank. If two handlers use the same identifier, application
 startup fails with an error that names the duplicated ID and both handler methods. Registration

--- a/docs/spring-modulith-1777-proposal.md
+++ b/docs/spring-modulith-1777-proposal.md
@@ -1,0 +1,47 @@
+# Spring Modulith issue 1777: stable handler identifiers
+
+Namastack stores a handler identifier on every outbox record so that the record can be routed back
+to the correct handler. Its default identifier contains the handler's concrete class and method
+signature. That is a useful zero-configuration default, but a refactoring or a generated framework
+handler class can make the identifier unstable while older records still refer to the previous one.
+
+The non-breaking solution is an optional default method on `OutboxHandler` and
+`OutboxTypedHandler`. Existing handlers inherit `getHandlerId() = null` and keep the generated
+identifier. An integration that owns a long-lived logical handler can override it with an identifier
+that is independent of its implementation:
+
+```java
+final class ModulithEventExternalizer implements OutboxHandler {
+
+    @Override
+    public String getHandlerId() {
+        return "spring-modulith-event-externalizer";
+    }
+}
+```
+
+The fallback variants inherit the same default method from `OutboxHandler` or
+`OutboxTypedHandler`; they do not need another identifier contract. A bean that only happens to
+declare a similarly named method is intentionally not treated as a handler—the ID is read only after
+the bean has been discovered through one of the existing handler interfaces.
+
+Annotation-based handlers can set the identifier per method, which also supports multiple handlers
+on the same bean:
+
+```java
+@OutboxHandler(id = "spring-modulith-event-externalizer")
+void externalize(Object event, OutboxRecordMetadata metadata) {
+    // ...
+}
+```
+
+Spring Modulith can implement this interface on its Namastack handler without changing either
+existing `OutboxHandler` implementations or the scheduling API. Namastack continues registering the
+previous generated identifier as a legacy alias, allowing records created before the integration
+adopts the stable identifier to drain normally. New records persist the explicit stable identifier.
+
+The configured identifier must be non-blank. If two handlers use the same identifier, application
+startup fails with an error that names the duplicated ID and both handler methods. Registration
+reserves the ID before changing any type indexes, so a rejected handler is never partially
+registered. This is preferable to silently routing both sets of persisted records to whichever
+handler happened to register last.

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/annotation/OutboxHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/annotation/OutboxHandler.kt
@@ -52,4 +52,12 @@ package io.namastack.outbox.annotation
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class OutboxHandler
+annotation class OutboxHandler(
+    /**
+     * Stable identifier persisted with records for this handler.
+     *
+     * Leave empty to retain the generated class-and-method identifier. The value must be unique
+     * among all handlers in the application.
+     */
+    val id: String = "",
+)

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/annotation/OutboxHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/annotation/OutboxHandler.kt
@@ -60,4 +60,11 @@ annotation class OutboxHandler(
      * among all handlers in the application.
      */
     val id: String = "",
+    /**
+     * Previous identifiers that must continue to resolve to this handler.
+     *
+     * Aliases are not persisted for new records. They are registered for lookup only and must be
+     * unique among all handler IDs and aliases in the application.
+     */
+    val aliases: Array<String> = [],
 )

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxHandler.kt
@@ -32,6 +32,14 @@ package io.namastack.outbox.handler
  */
 interface OutboxHandler {
     /**
+     * Returns the stable identifier to persist with records for this handler.
+     *
+     * Override this when the identifier must remain independent of implementation class or method
+     * renames. Returning `null` keeps the generated class-and-method identifier.
+     */
+    fun getHandlerId(): String? = null
+
+    /**
      * Determines whether this handler supports scheduling for a given payload.
      *
      * Called before an outbox record is created. Return `false` to prevent

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxHandler.kt
@@ -40,6 +40,13 @@ interface OutboxHandler {
     fun getHandlerId(): String? = null
 
     /**
+     * Returns previous identifiers that must continue to resolve to this handler.
+     *
+     * Aliases are used for lookup only and must be unique among all handler IDs and aliases.
+     */
+    fun getHandlerAliases(): Set<String> = emptySet()
+
+    /**
      * Determines whether this handler supports scheduling for a given payload.
      *
      * Called before an outbox record is created. Return `false` to prevent

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxTypedHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxTypedHandler.kt
@@ -48,6 +48,13 @@ interface OutboxTypedHandler<T> {
     fun getHandlerId(): String? = null
 
     /**
+     * Returns previous identifiers that must continue to resolve to this handler.
+     *
+     * Aliases are used for lookup only and must be unique among all handler IDs and aliases.
+     */
+    fun getHandlerAliases(): Set<String> = emptySet()
+
+    /**
      * Handles an outbox record with payload and metadata.
      *
      * @param payload The record payload of type [T]

--- a/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxTypedHandler.kt
+++ b/namastack-outbox-api/src/main/kotlin/io/namastack/outbox/handler/OutboxTypedHandler.kt
@@ -40,6 +40,14 @@ package io.namastack.outbox.handler
  */
 interface OutboxTypedHandler<T> {
     /**
+     * Returns the stable identifier to persist with records for this handler.
+     *
+     * Override this when the identifier must remain independent of implementation class or method
+     * renames. Returning `null` keeps the generated class-and-method identifier.
+     */
+    fun getHandlerId(): String? = null
+
+    /**
      * Handles an outbox record with payload and metadata.
      *
      * @param payload The record payload of type [T]

--- a/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerTest.kt
+++ b/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerTest.kt
@@ -8,6 +8,13 @@ import java.time.Instant
 @DisplayName("OutboxHandler")
 class OutboxHandlerTest {
     @Test
+    fun `handler ID defaults to null`() {
+        val handler = TestHandler()
+
+        assertThat(handler.getHandlerId()).isNull()
+    }
+
+    @Test
     fun `supports defaults to true`() {
         val handler =
             object : OutboxHandler {
@@ -31,4 +38,13 @@ class OutboxHandlerTest {
             createdAt = Instant.now(),
             context = emptyMap(),
         )
+
+    private class TestHandler : OutboxHandler {
+        override fun handle(
+            payload: Any,
+            metadata: OutboxRecordMetadata,
+        ) {
+            // no-op
+        }
+    }
 }

--- a/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerTest.kt
+++ b/namastack-outbox-api/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerTest.kt
@@ -12,6 +12,7 @@ class OutboxHandlerTest {
         val handler = TestHandler()
 
         assertThat(handler.getHandlerId()).isNull()
+        assertThat(handler.getHandlerAliases()).isEmpty()
     }
 
     @Test

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
@@ -2,7 +2,6 @@ package io.namastack.outbox.handler
 
 import io.namastack.outbox.handler.registry.OutboxFallbackHandlerRegistry
 import io.namastack.outbox.handler.registry.OutboxHandlerRegistry
-import io.namastack.outbox.handler.scanner.HandlerScanResult
 import io.namastack.outbox.handler.scanner.RetryPolicyScanner
 import io.namastack.outbox.handler.scanner.handler.AnnotatedHandlerScanner
 import io.namastack.outbox.handler.scanner.handler.InterfaceHandlerScanner
@@ -52,7 +51,7 @@ internal class OutboxHandlerBeanPostProcessor(
      * Scans for handlers and their fallbacks, then registers them:
      * 1. Scan bean for handlers using all scanners
      * 2. Register handler in handler registry
-     * 3. Register legacy alias if bean is an AOP proxy (backward compatibility)
+     * 3. Register all handler aliases for backward compatibility
      * 4. Register fallback (if present) with handler.id
      * 5. Register retry policy for handler
      *
@@ -67,7 +66,7 @@ internal class OutboxHandlerBeanPostProcessor(
         // 1. Scan for all handlers and their fallbacks in this bean
         val scanResults = handlerScanners.flatMap { it.scan(bean) }
 
-        // 2. For each result: register handler + fallback + retry policy + legacy alias
+        // 2. For each result: register handler + fallback + retry policy under all routing IDs
         scanResults.forEach { result ->
             val handler = result.handler
 
@@ -77,40 +76,18 @@ internal class OutboxHandlerBeanPostProcessor(
             // b. Register fallback if present (1:1 mapping)
             result.fallback?.let { fallback ->
                 fallbackHandlerRegistry.register(handler.id, fallback)
+                handler.aliases.forEach { fallbackHandlerRegistry.registerAlias(it, fallback) }
             }
 
             // c. Register retry policy for this handler
             retryPolicyScanners
                 .mapNotNull { it.scan(handler) }
-                .forEach { policy -> retryPolicyRegistry.register(handler.id, policy) }
-
-            // d. Register legacy alias if bean is an AOP proxy (backward compatibility)
-            if (handler.id != handler.legacyId) {
-                registerLegacyAliases(handler.legacyId, result)
-            }
+                .forEach { policy ->
+                    retryPolicyRegistry.register(handler.id, policy)
+                    handler.aliases.forEach { retryPolicyRegistry.registerAlias(it, policy) }
+                }
         }
 
         return bean
-    }
-
-    /**
-     * Registers legacy alias IDs in all registries for backward compatibility
-     * with existing database records that reference CGLIB proxy class names.
-     */
-    private fun registerLegacyAliases(
-        legacyId: String,
-        result: HandlerScanResult,
-    ) {
-        val handler = result.handler
-
-        handlerRegistry.registerAlias(legacyId, handler)
-
-        result.fallback?.let { fallback ->
-            fallbackHandlerRegistry.registerAlias(legacyId, fallback)
-        }
-
-        retryPolicyScanners
-            .mapNotNull { it.scan(handler) }
-            .forEach { policy -> retryPolicyRegistry.registerAlias(legacyId, policy) }
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
@@ -1,6 +1,10 @@
 package io.namastack.outbox.handler.method
 
+import io.namastack.outbox.annotation.OutboxHandler as OutboxHandlerAnnotation
+import io.namastack.outbox.handler.OutboxHandler
+import io.namastack.outbox.handler.OutboxTypedHandler
 import io.namastack.outbox.handler.method.internal.ReflectionUtils
+import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
@@ -20,20 +24,46 @@ abstract class BaseHandlerMethod(
 ) {
     /**
      * Unique identifier for routing and tracking.
-     * Format: `ClassName#methodName(Type1,Type2,...)`
+     * Uses an explicit annotation or provider ID when available, otherwise the format
+     * `ClassName#methodName(Type1,Type2,...)`.
      */
     val id: String = buildId()
 
     /**
-     * Builds unique ID from class name, method name, and parameter types.
-     * ID remains stable across restarts for persistent record association.
+     * Resolves an explicit stable ID before falling back to the generated method ID.
      */
     protected fun buildId(): String {
-        val className = ReflectionUtils.getTargetClass(bean).name
-        val methodName = method.name
-        val paramTypes = method.parameterTypes.joinToString(",") { it.name }
+        val annotatedId =
+            AnnotatedElementUtils
+                .findMergedAnnotation(method, OutboxHandlerAnnotation::class.java)
+                ?.id
+                ?.takeIf(String::isNotEmpty)
 
-        return "$className#$methodName($paramTypes)"
+        if (annotatedId != null) return validateId(annotatedId)
+
+        val providedId = getProvidedId()
+
+        return providedId?.let(::validateId) ?: buildGeneratedId()
+    }
+
+    /** Returns the ID supplied by an interface-based handler, when configured. */
+    private fun getProvidedId(): String? =
+        when (bean) {
+            is OutboxHandler -> bean.getHandlerId()
+            is OutboxTypedHandler<*> -> bean.getHandlerId()
+            else -> null
+        }
+
+    /** Validates an explicitly configured handler ID. */
+    private fun validateId(id: String): String =
+        id.also {
+            require(it.isNotBlank()) { "Outbox handler ID must not be blank" }
+        }
+
+    /** Builds the default stable ID from the target class and handler method. */
+    private fun buildGeneratedId(): String {
+        val className = ReflectionUtils.getTargetClass(bean).name
+        return buildMethodId(className)
     }
 
     /**
@@ -47,6 +77,11 @@ abstract class BaseHandlerMethod(
      */
     protected fun buildLegacyId(): String {
         val className = bean::class.java.name
+        return buildMethodId(className)
+    }
+
+    /** Builds the canonical method identifier for the supplied class name. */
+    private fun buildMethodId(className: String): String {
         val methodName = method.name
         val paramTypes = method.parameterTypes.joinToString(",") { it.name }
 

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
@@ -1,12 +1,12 @@
 package io.namastack.outbox.handler.method
 
-import io.namastack.outbox.annotation.OutboxHandler as OutboxHandlerAnnotation
 import io.namastack.outbox.handler.OutboxHandler
 import io.namastack.outbox.handler.OutboxTypedHandler
 import io.namastack.outbox.handler.method.internal.ReflectionUtils
 import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
+import io.namastack.outbox.annotation.OutboxHandler as OutboxHandlerAnnotation
 
 /**
  * Base class for all handler method wrappers providing common ID generation and invocation logic.

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
@@ -27,23 +27,37 @@ abstract class BaseHandlerMethod(
      * Uses an explicit annotation or provider ID when available, otherwise the format
      * `ClassName#methodName(Type1,Type2,...)`.
      */
+    private val annotation =
+        AnnotatedElementUtils.findMergedAnnotation(method, OutboxHandlerAnnotation::class.java)
+
+    private val generatedId: String = buildGeneratedId()
+
+    private val runtimeClassId: String = buildMethodId(bean::class.java.name)
+
     val id: String = buildId()
+
+    /**
+     * Alternative routing identifiers for records persisted with a previous handler ID.
+     *
+     * This includes configured aliases, the generated target-class ID when an explicit ID is used,
+     * and the historical runtime proxy-class ID when it differs.
+     */
+    val aliases: Set<String> = buildAliases()
+
+    /** Historical runtime-class identifier, retained for source compatibility. */
+    val legacyId: String = runtimeClassId
 
     /**
      * Resolves an explicit stable ID before falling back to the generated method ID.
      */
     protected fun buildId(): String {
-        val annotatedId =
-            AnnotatedElementUtils
-                .findMergedAnnotation(method, OutboxHandlerAnnotation::class.java)
-                ?.id
-                ?.takeIf(String::isNotEmpty)
+        val annotatedId = annotation?.id?.takeIf(String::isNotEmpty)
 
         if (annotatedId != null) return validateId(annotatedId)
 
         val providedId = getProvidedId()
 
-        return providedId?.let(::validateId) ?: buildGeneratedId()
+        return providedId?.let(::validateId) ?: generatedId
     }
 
     /** Returns the ID supplied by an interface-based handler, when configured. */
@@ -54,29 +68,35 @@ abstract class BaseHandlerMethod(
             else -> null
         }
 
+    private fun getConfiguredAliases(): Set<String> =
+        when (bean) {
+            is OutboxHandler -> bean.getHandlerAliases()
+            is OutboxTypedHandler<*> -> bean.getHandlerAliases()
+            else -> annotation?.aliases?.toSet().orEmpty()
+        }
+
+    private fun buildAliases(): Set<String> =
+        buildSet {
+            getConfiguredAliases().forEach { add(validateAlias(it)) }
+            add(generatedId)
+            add(runtimeClassId)
+            remove(id)
+        }
+
     /** Validates an explicitly configured handler ID. */
     private fun validateId(id: String): String =
         id.also {
             require(it.isNotBlank()) { "Outbox handler ID must not be blank" }
         }
 
+    private fun validateAlias(alias: String): String =
+        alias.also {
+            require(it.isNotBlank()) { "Outbox handler alias must not be blank" }
+        }
+
     /** Builds the default stable ID from the target class and handler method. */
     private fun buildGeneratedId(): String {
         val className = ReflectionUtils.getTargetClass(bean).name
-        return buildMethodId(className)
-    }
-
-    /**
-     * Legacy identifier using the bean's runtime class name, which may include
-     * CGLIB proxy suffixes like `$$SpringCGLIB$$0`.
-     */
-    val legacyId: String = buildLegacyId()
-
-    /**
-     * Builds a legacy handler ID using the bean's runtime class name.
-     */
-    protected fun buildLegacyId(): String {
-        val className = bean::class.java.name
         return buildMethodId(className)
     }
 

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxFallbackHandlerRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxFallbackHandlerRegistry.kt
@@ -63,28 +63,19 @@ class OutboxFallbackHandlerRegistry {
     internal fun register(
         handlerId: String,
         fallbackHandlerMethod: OutboxFallbackHandlerMethod,
+    ) = registerAll(setOf(handlerId), fallbackHandlerMethod)
+
+    internal fun registerAll(
+        handlerIds: Set<String>,
+        fallbackHandlerMethod: OutboxFallbackHandlerMethod,
     ) {
-        check(fallbackHandlersByHandlerId.putIfAbsent(handlerId, fallbackHandlerMethod) == null) {
-            "Multiple fallback handlers for handler ID detected: $handlerId"
-        }
+        val duplicate = handlerIds.firstOrNull(fallbackHandlersByHandlerId::containsKey)
+        check(duplicate == null) { "Multiple fallback handlers for handler ID detected (ID or alias): $duplicate" }
+        handlerIds.forEach { fallbackHandlersByHandlerId[it] = fallbackHandlerMethod }
     }
 
-    /**
-     * Registers a legacy alias ID that points to the same fallback handler.
-     *
-     * Used for backward compatibility when handler IDs in existing database records
-     * were generated using CGLIB proxy class names.
-     *
-     * @param aliasId The legacy handler ID to register as an alias
-     * @param fallbackHandlerMethod The fallback handler method this alias should resolve to
-     * @throws IllegalStateException if the alias ID is already registered
-     */
     internal fun registerAlias(
         aliasId: String,
         fallbackHandlerMethod: OutboxFallbackHandlerMethod,
-    ) {
-        check(fallbackHandlersByHandlerId.putIfAbsent(aliasId, fallbackHandlerMethod) == null) {
-            "Duplicate fallback alias ID detected: $aliasId"
-        }
-    }
+    ) = registerAll(setOf(aliasId), fallbackHandlerMethod)
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxHandlerRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxHandlerRegistry.kt
@@ -115,6 +115,10 @@ class OutboxHandlerRegistry {
      * @throws IllegalStateException if a handler with the same ID already exists
      */
     internal fun register(handlerMethod: OutboxHandlerMethod) {
+        // Validate and reserve the persisted ID before updating the type indexes. This makes
+        // registration atomic when two handlers explicitly choose the same stable identifier.
+        registerInAllHandlers(handlerMethod)
+
         when (handlerMethod) {
             is TypedHandlerMethod -> {
                 typedHandlers
@@ -126,8 +130,6 @@ class OutboxHandlerRegistry {
                 genericHandlers.add(handlerMethod)
             }
         }
-
-        registerInAllHandlers(handlerMethod)
     }
 
     /**
@@ -140,8 +142,12 @@ class OutboxHandlerRegistry {
      * @throws IllegalStateException if a handler with the same ID is already registered
      */
     private fun registerInAllHandlers(handlerMethod: OutboxHandlerMethod) {
-        check(handlersById.putIfAbsent(handlerMethod.id, handlerMethod) == null) {
-            "Duplicate handler ID detected: ${handlerMethod.id}"
+        val existing = handlersById.putIfAbsent(handlerMethod.id, handlerMethod)
+
+        check(existing == null) {
+            "Duplicate handler ID '${handlerMethod.id}' detected for " +
+                "${existing?.method?.toGenericString()} and ${handlerMethod.method.toGenericString()}. " +
+                "Each outbox handler must use a unique ID."
         }
     }
 

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxHandlerRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/registry/OutboxHandlerRegistry.kt
@@ -115,9 +115,7 @@ class OutboxHandlerRegistry {
      * @throws IllegalStateException if a handler with the same ID already exists
      */
     internal fun register(handlerMethod: OutboxHandlerMethod) {
-        // Validate and reserve the persisted ID before updating the type indexes. This makes
-        // registration atomic when two handlers explicitly choose the same stable identifier.
-        registerInAllHandlers(handlerMethod)
+        registerRoutingIds(handlerMethod)
 
         when (handlerMethod) {
             is TypedHandlerMethod -> {
@@ -141,14 +139,18 @@ class OutboxHandlerRegistry {
      * @param handlerMethod The handler method to register globally
      * @throws IllegalStateException if a handler with the same ID is already registered
      */
-    private fun registerInAllHandlers(handlerMethod: OutboxHandlerMethod) {
-        val existing = handlersById.putIfAbsent(handlerMethod.id, handlerMethod)
+    private fun registerRoutingIds(handlerMethod: OutboxHandlerMethod) {
+        val routingIds = setOf(handlerMethod.id) + handlerMethod.aliases
+        val collision = routingIds.firstNotNullOfOrNull { id -> handlersById[id]?.let { id to it } }
 
-        check(existing == null) {
-            "Duplicate handler ID '${handlerMethod.id}' detected for " +
-                "${existing?.method?.toGenericString()} and ${handlerMethod.method.toGenericString()}. " +
-                "Each outbox handler must use a unique ID."
+        check(collision == null) {
+            val (id, existing) = requireNotNull(collision)
+            "Duplicate handler ID '$id' or alias detected for " +
+                "${existing.method.toGenericString()} and ${handlerMethod.method.toGenericString()}. " +
+                "Each outbox handler must use a unique ID; aliases must also be unique."
         }
+
+        routingIds.forEach { handlersById[it] = handlerMethod }
     }
 
     private fun OutboxHandlerMethod.toDescriptor(): OutboxHandlerDescriptor {
@@ -165,26 +167,12 @@ class OutboxHandlerRegistry {
         )
     }
 
-    /**
-     * Registers a legacy alias ID that points to the same handler.
-     *
-     * Used for backward compatibility when handler IDs in existing database records
-     * were generated using CGLIB proxy class names. The alias allows those old records
-     * to still find their handler after upgrading to stable (non-proxy) IDs.
-     *
-     * Unlike [register], this method only adds to the ID-based lookup map
-     * (not to typed/generic handler lists).
-     *
-     * @param aliasId The legacy handler ID to register as an alias
-     * @param handlerMethod The handler method this alias should resolve to
-     * @throws IllegalStateException if the alias ID is already registered
-     */
     internal fun registerAlias(
         aliasId: String,
         handlerMethod: OutboxHandlerMethod,
     ) {
         check(handlersById.putIfAbsent(aliasId, handlerMethod) == null) {
-            "Duplicate alias ID detected: $aliasId"
+            "Duplicate handler ID or alias detected: $aliasId"
         }
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyRegistry.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/retry/OutboxRetryPolicyRegistry.kt
@@ -58,24 +58,17 @@ class OutboxRetryPolicyRegistry(
         policiesById[handlerId] = policy
     }
 
-    /**
-     * Registers a legacy alias ID that points to the same retry policy.
-     *
-     * Used for backward compatibility when handler IDs in existing database records
-     * were generated using CGLIB proxy class names.
-     *
-     * @param aliasId The legacy handler ID to register as an alias
-     * @param policy The retry policy this alias should resolve to
-     * @throws IllegalStateException if the alias ID is already registered
-     */
+    fun registerAll(
+        handlerIds: Set<String>,
+        policy: OutboxRetryPolicy,
+    ) {
+        handlerIds.forEach { policiesById[it] = policy }
+    }
+
     fun registerAlias(
         aliasId: String,
         policy: OutboxRetryPolicy,
-    ) {
-        check(policiesById.putIfAbsent(aliasId, policy) == null) {
-            "Duplicate retry policy alias ID detected: $aliasId"
-        }
-    }
+    ) = registerAll(setOf(aliasId), policy)
 
     /**
      * Retrieves the retry policy for a specific handler method.

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
@@ -17,9 +17,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.aop.framework.ProxyFactory
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import kotlin.reflect.KClass
 
 @DisplayName("OutboxHandlerBeanPostProcessor")
@@ -325,7 +322,6 @@ class OutboxHandlerBeanPostProcessorTest {
     @Nested
     @DisplayName("Legacy alias registration for CGLIB proxies")
     inner class LegacyAliasTests {
-        private val clock = Clock.fixed(Instant.parse("2025-09-25T10:00:00Z"), ZoneOffset.UTC)
         private val realHandlerRegistry = OutboxHandlerRegistry()
         private val realFallbackRegistry = OutboxFallbackHandlerRegistry()
 
@@ -355,6 +351,28 @@ class OutboxHandlerBeanPostProcessorTest {
             // Both should resolve to the same handler
             assertThat(realHandlerRegistry.getHandlerById(handler.id))
                 .isSameAs(realHandlerRegistry.getHandlerById(handler.legacyId))
+        }
+
+        @Test
+        fun `registers configured generated and proxy aliases for explicit ID`() {
+            val proxiedBean = createCglibProxy(OpenIdentifiedAnnotatedHandler())
+
+            proxyProcessor.postProcessAfterInitialization(proxiedBean, "bean")
+
+            val handler = realHandlerRegistry.getHandlersForPayloadType(String::class).first()
+            val generatedAlias =
+                handler.aliases.single {
+                    it.contains(OpenIdentifiedAnnotatedHandler::class.java.name) &&
+                        !it.contains("CGLIB")
+                }
+            val proxyAlias = handler.aliases.single { it.contains("CGLIB") }
+
+            assertThat(handler.id).isEqualTo("identified-handler")
+            assertThat(handler.aliases).contains("configured-old-id", generatedAlias, proxyAlias)
+            assertThat(realHandlerRegistry.getHandlerById("identified-handler")).isSameAs(handler)
+            assertThat(realHandlerRegistry.getHandlerById("configured-old-id")).isSameAs(handler)
+            assertThat(realHandlerRegistry.getHandlerById(generatedAlias)).isSameAs(handler)
+            assertThat(realHandlerRegistry.getHandlerById(proxyAlias)).isSameAs(handler)
         }
 
         @Test
@@ -419,6 +437,19 @@ open class OpenAnnotatedTypedHandlerWithFallback {
     open fun handleFailure(
         payload: String,
         context: OutboxFailureContext,
+    ) {
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+open class OpenIdentifiedAnnotatedHandler {
+    @io.namastack.outbox.annotation.OutboxHandler(
+        id = "identified-handler",
+        aliases = ["configured-old-id"],
+    )
+    open fun handle(
+        payload: String,
+        metadata: OutboxRecordMetadata,
     ) {
     }
 }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerRegistryTest.kt
@@ -189,6 +189,31 @@ class OutboxHandlerRegistryTest {
     @DisplayName("registerAlias()")
     inner class RegisterAliasTests {
         @Test
+        fun `registers all aliases with the handler`() {
+            val handler = createMockTypedHandler("stable-id", TestPayload::class, setOf("old-id", "older-id"))
+
+            registry.register(handler)
+
+            assertThat(registry.getHandlerById("old-id")).isSameAs(handler)
+            assertThat(registry.getHandlerById("older-id")).isSameAs(handler)
+        }
+
+        @Test
+        fun `rejects alias collision without partially registering handler`() {
+            val existing = createMockTypedHandler("existing-id", TestPayload::class)
+            val rejected = createMockTypedHandler("new-id", AnotherPayload::class, setOf("free-alias", "existing-id"))
+            registry.register(existing)
+
+            assertThatThrownBy { registry.register(rejected) }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("existing-id")
+
+            assertThat(registry.getHandlerById("new-id")).isNull()
+            assertThat(registry.getHandlerById("free-alias")).isNull()
+            assertThat(registry.getHandlersForPayloadType(AnotherPayload::class)).isEmpty()
+        }
+
+        @Test
         fun `should allow lookup by alias ID`() {
             val handler = createMockTypedHandler("stable-id", TestPayload::class)
             registry.register(handler)
@@ -308,10 +333,12 @@ class OutboxHandlerRegistryTest {
     private fun createMockTypedHandler(
         id: String,
         paramType: KClass<*>,
+        aliases: Set<String> = emptySet(),
     ): TypedHandlerMethod {
         val method = TestHandler::class.java.getMethod("handle", paramType.java)
         val handler = mockk<TypedHandlerMethod>()
         every { handler.id } returns id
+        every { handler.aliases } returns aliases
         every { handler.paramType } returns paramType
         every { handler.bean } returns TestHandler()
         every { handler.method } returns method
@@ -330,6 +357,7 @@ class OutboxHandlerRegistryTest {
             )
         val handler = mockk<GenericHandlerMethod>()
         every { handler.id } returns id
+        every { handler.aliases } returns emptySet()
         every { handler.supportsScheduling(any(), any()) } returns supports
         every { handler.bean } returns TestHandler()
         every { handler.method } returns method

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerRegistryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerRegistryTest.kt
@@ -86,16 +86,13 @@ class OutboxHandlerRegistryTest {
 
             registry.register(handler1)
 
-            val exception =
-                try {
-                    registry.register(handler2)
-                    null
-                } catch (e: IllegalStateException) {
-                    e
-                }
+            assertThatThrownBy { registry.register(handler2) }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("Duplicate handler ID 'duplicate-id'")
+                .hasMessageContaining("Each outbox handler must use a unique ID")
 
-            assertThat(exception).isNotNull()
-            assertThat(exception?.message).contains("duplicate")
+            assertThat(registry.getHandlersForPayloadType(AnotherPayload::class)).isEmpty()
+            assertThat(registry.getHandlerById("duplicate-id")).isSameAs(handler1)
         }
     }
 
@@ -149,15 +146,12 @@ class OutboxHandlerRegistryTest {
 
             registry.register(handler1)
 
-            val exception =
-                try {
-                    registry.register(handler2)
-                    null
-                } catch (e: IllegalStateException) {
-                    e
-                }
+            assertThatThrownBy { registry.register(handler2) }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("Duplicate handler ID 'duplicate-id'")
 
-            assertThat(exception).isNotNull()
+            assertThat(registry.getGenericHandlers(1) { metadata(handlerId = it.id) }).isEmpty()
+            assertThat(registry.getHandlerById("duplicate-id")).isSameAs(handler1)
         }
     }
 

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethodTest.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox.handler.method.handler
 
+import io.namastack.outbox.annotation.OutboxHandler
 import io.namastack.outbox.handler.OutboxRecordMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -8,6 +9,21 @@ import java.time.Instant
 
 @DisplayName("GenericHandlerAnnotationMethod")
 class GenericHandlerAnnotationMethodTest {
+    @Test
+    fun `uses stable ID declared on annotation`() {
+        val bean = StableIdAnnotatedHandler()
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                Any::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+
+        val handler = GenericHandlerAnnotationMethod(bean, method)
+
+        assertThat(handler.id).isEqualTo("spring-modulith-event-externalizer")
+    }
+
     @Test
     fun `supportsScheduling defaults to true for non OutboxHandler beans`() {
         val bean = AnnotatedStyleGenericHandler()
@@ -40,5 +56,14 @@ class GenericHandlerAnnotationMethodTest {
         ) {
             // no-op
         }
+    }
+
+    private class StableIdAnnotatedHandler {
+        @OutboxHandler(id = "spring-modulith-event-externalizer")
+        @Suppress("UNUSED_PARAMETER")
+        fun handle(
+            payload: Any,
+            metadata: OutboxRecordMetadata,
+        ) = Unit
     }
 }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethodTest.kt
@@ -22,6 +22,9 @@ class GenericHandlerAnnotationMethodTest {
         val handler = GenericHandlerAnnotationMethod(bean, method)
 
         assertThat(handler.id).isEqualTo("spring-modulith-event-externalizer")
+        assertThat(handler.aliases)
+            .contains("previous-externalizer")
+            .anyMatch { it.contains(StableIdAnnotatedHandler::class.java.name) }
     }
 
     @Test
@@ -59,7 +62,10 @@ class GenericHandlerAnnotationMethodTest {
     }
 
     private class StableIdAnnotatedHandler {
-        @OutboxHandler(id = "spring-modulith-event-externalizer")
+        @OutboxHandler(
+            id = "spring-modulith-event-externalizer",
+            aliases = ["previous-externalizer"],
+        )
         @Suppress("UNUSED_PARAMETER")
         fun handle(
             payload: Any,

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
@@ -23,7 +23,9 @@ class GenericHandlerInterfaceMethodTest {
         val handler = GenericHandlerInterfaceMethod(bean, method)
 
         assertThat(handler.id).isEqualTo("spring-modulith-event-externalizer")
-        assertThat(handler.legacyId).contains(IdentifiedGenericHandler::class.java.name)
+        assertThat(handler.aliases)
+            .contains("previous-externalizer")
+            .anyMatch { it.contains(IdentifiedGenericHandler::class.java.name) }
     }
 
     @Test
@@ -85,6 +87,8 @@ class GenericHandlerInterfaceMethodTest {
         private val handlerId: String,
     ) : OutboxHandler {
         override fun getHandlerId(): String = handlerId
+
+        override fun getHandlerAliases(): Set<String> = setOf("previous-externalizer")
 
         override fun handle(
             payload: Any,

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
@@ -3,12 +3,44 @@ package io.namastack.outbox.handler.method.handler
 import io.namastack.outbox.handler.OutboxHandler
 import io.namastack.outbox.handler.OutboxRecordMetadata
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
 @DisplayName("GenericHandlerInterfaceMethod")
 class GenericHandlerInterfaceMethodTest {
+    @Test
+    fun `uses explicitly supplied stable handler ID`() {
+        val bean = IdentifiedGenericHandler("spring-modulith-event-externalizer")
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                Any::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+
+        val handler = GenericHandlerInterfaceMethod(bean, method)
+
+        assertThat(handler.id).isEqualTo("spring-modulith-event-externalizer")
+        assertThat(handler.legacyId).contains(IdentifiedGenericHandler::class.java.name)
+    }
+
+    @Test
+    fun `rejects a blank explicitly supplied handler ID`() {
+        val bean = IdentifiedGenericHandler(" ")
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                Any::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { GenericHandlerInterfaceMethod(bean, method) }
+            .withMessage("Outbox handler ID must not be blank")
+    }
+
     @Test
     fun `supportsScheduling delegates to OutboxHandler supports`() {
         val bean = ConditionalGenericHandler(supported = false)
@@ -40,6 +72,19 @@ class GenericHandlerInterfaceMethodTest {
             payload: Any,
             metadata: OutboxRecordMetadata,
         ): Boolean = supported
+
+        override fun handle(
+            payload: Any,
+            metadata: OutboxRecordMetadata,
+        ) {
+            // no-op
+        }
+    }
+
+    private class IdentifiedGenericHandler(
+        private val handlerId: String,
+    ) : OutboxHandler {
+        override fun getHandlerId(): String = handlerId
 
         override fun handle(
             payload: Any,

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/TypedHandlerMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/TypedHandlerMethodTest.kt
@@ -1,6 +1,7 @@
 package io.namastack.outbox.handler.method.handler
 
 import io.namastack.outbox.handler.OutboxRecordMetadata
+import io.namastack.outbox.handler.OutboxTypedHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -9,6 +10,21 @@ import org.springframework.aop.framework.ProxyFactory
 
 @DisplayName("TypedHandlerMethod")
 class TypedHandlerMethodTest {
+    @Test
+    fun `uses stable ID supplied by typed handler`() {
+        val bean = IdentifiedTypedHandler()
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                String::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+
+        val handler = TypedHandlerMethod(bean, method)
+
+        assertThat(handler.id).isEqualTo("typed-event-externalizer")
+    }
+
     @Nested
     @DisplayName("invoke() with 1-parameter signature")
     inner class InvokeOneParamTests {
@@ -248,4 +264,15 @@ class TypedHandlerMethodTest {
     data class TestPayload(
         val id: String,
     )
+
+    private class IdentifiedTypedHandler : OutboxTypedHandler<String> {
+        override fun getHandlerId(): String = "typed-event-externalizer"
+
+        override fun handle(
+            payload: String,
+            metadata: OutboxRecordMetadata,
+        ) {
+            // no-op
+        }
+    }
 }

--- a/namastack-outbox-docs/docs/reference/handlers.md
+++ b/namastack-outbox-docs/docs/reference/handlers.md
@@ -21,7 +21,7 @@ The library provides two complementary handler interfaces for different use case
 ```kotlin
 @Component
 class OrderCreatedHandler : OutboxTypedHandler<OrderCreatedRecord> {
-    override fun handle(payload: OrderCreatedRecord) {
+    override fun handle(payload: OrderCreatedRecord, metadata: OutboxRecordMetadata) {
         println("Processing order: ${payload.orderId}")
         eventPublisher.publish(payload)
     }
@@ -35,7 +35,7 @@ class OrderCreatedHandler : OutboxTypedHandler<OrderCreatedRecord> {
 @Component
 public class OrderCreatedHandler implements OutboxTypedHandler<OrderCreatedRecord> {
     @Override
-    public void handle(OrderCreatedRecord payload) {
+    public void handle(OrderCreatedRecord payload, OutboxRecordMetadata metadata) {
         System.out.println("Processing order: " + payload.getOrderId());
         eventPublisher.publish(payload);
     }
@@ -162,6 +162,169 @@ public class MyHandlers {
 
 - **Interfaces**: Best when entire class is dedicated to handling a single type
 - **Annotations**: Best when a class handles multiple types or mixing with other logic
+:::
+
+---
+
+## Stable Handler IDs and Aliases
+
+Namastack stores the handler ID on every outbox record so that the record can be routed to the
+same handler later. By default, this ID is generated from the handler's target class and method
+signature. This requires no configuration, but renaming or moving a handler changes its generated
+ID while older records may still reference the previous one.
+
+Use an explicit ID when the logical identity of a handler should remain stable across such
+refactorings. New records persist the explicit ID; aliases are used only when resolving existing
+records.
+
+### Annotation-based Handlers
+
+Set `id` on each annotated handler method. This also allows multiple methods in the same class to
+have independent stable IDs.
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+@Component
+class OrderHandlers {
+    @OutboxHandler(id = "order-created")
+    fun handleOrderCreated(payload: OrderCreatedRecord) {
+        // ...
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+@Component
+public class OrderHandlers {
+    @OutboxHandler(id = "order-created")
+    public void handleOrderCreated(OrderCreatedRecord payload) {
+        // ...
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Interface-based Handlers
+
+Override `getHandlerId()` on `OutboxHandler` or `OutboxTypedHandler`. The fallback variants inherit
+the same identifier contract.
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+@Component
+class OrderCreatedHandler : OutboxTypedHandler<OrderCreatedRecord> {
+    override fun getHandlerId(): String = "order-created"
+
+    override fun handle(payload: OrderCreatedRecord, metadata: OutboxRecordMetadata) {
+        // ...
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+@Component
+public class OrderCreatedHandler implements OutboxTypedHandler<OrderCreatedRecord> {
+    @Override
+    public String getHandlerId() {
+        return "order-created";
+    }
+
+    @Override
+    public void handle(OrderCreatedRecord payload, OutboxRecordMetadata metadata) {
+        // ...
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+Leaving the annotation ID empty or returning `null` from `getHandlerId()` retains the generated
+class-and-method ID.
+
+### Migrating Existing Handlers
+
+When an existing handler adopts an explicit ID, Namastack automatically registers its previous
+generated target-class ID as an alias. For proxied handlers, the historical runtime proxy-class ID
+is registered as an additional alias. Records queued before the change can therefore continue to
+resolve the handler, while newly scheduled records use the explicit ID.
+
+If the class or method was already renamed, Namastack cannot derive the old identifier. Declare it
+explicitly as an alias instead:
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+@OutboxHandler(
+    id = "order-created",
+    aliases = ["com.example.LegacyOrderHandler#handle(com.example.OrderCreatedRecord)"],
+)
+fun handleOrderCreated(payload: OrderCreatedRecord) {
+    // ...
+}
+```
+
+For interface-based handlers, override `getHandlerAliases()`:
+
+```kotlin
+override fun getHandlerId(): String = "order-created"
+
+override fun getHandlerAliases(): Set<String> =
+    setOf("com.example.LegacyOrderHandler#handle(com.example.OrderCreatedRecord)")
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+@OutboxHandler(
+    id = "order-created",
+    aliases = { "com.example.LegacyOrderHandler#handle(com.example.OrderCreatedRecord)" }
+)
+public void handleOrderCreated(OrderCreatedRecord payload) {
+    // ...
+}
+```
+
+For interface-based handlers, override `getHandlerAliases()`:
+
+```java
+@Override
+public String getHandlerId() {
+    return "order-created";
+}
+
+@Override
+public Set<String> getHandlerAliases() {
+    return Set.of("com.example.LegacyOrderHandler#handle(com.example.OrderCreatedRecord)");
+}
+```
+
+</TabItem>
+</Tabs>
+
+:::warning ID and Alias Requirements
+
+- IDs and aliases must not be blank.
+- Every canonical ID and alias must be globally unique across all handlers.
+- Repeating the canonical ID or an alias within the same handler is deduplicated.
+- A collision between two handlers causes application startup to fail rather than routing records
+  ambiguously.
+- Aliases are lookup-only; only the canonical handler ID is persisted for new records.
+
 :::
 
 ---


### PR DESCRIPTION
### Motivation

- Make persisted outbox handler identifiers stable across refactors or generated proxy class name changes so long-lived records continue to route correctly.
- Allow integrations to explicitly declare a stable handler ID from either annotations or handler interfaces to decouple persisted IDs from implementation details.
- Validate configured IDs and fail fast on duplicates to avoid ambiguous routing of persisted records.

### Description

- Added `id: String = ""` to the `@OutboxHandler` annotation to allow per-method stable IDs and detect non-empty annotated IDs in method-based handlers.
- Introduced a default `fun getHandlerId(): String? = null` on both `OutboxHandler` and `OutboxTypedHandler` so interface-based handlers can supply a stable ID without breaking existing implementations.
- Updated `BaseHandlerMethod` to resolve handler IDs in order: annotation ID (if present), interface-provided ID, and finally the generated `ClassName#methodName(paramTypes)` ID, with validation that explicit IDs are non-blank and a consolidated legacy ID generation.
- Made registration atomic in `OutboxHandlerRegistry` by reserving the ID in the global map before updating type-specific indexes and improved duplicate-ID error messages; added and adjusted tests to cover annotation IDs, interface IDs, blank-ID rejection, and duplicate registration behavior.

### Testing

- Added and updated unit tests including `OutboxHandlerTest`, `GenericHandlerAnnotationMethodTest`, `GenericHandlerInterfaceMethodTest`, `TypedHandlerMethodTest`, and `OutboxHandlerRegistryTest` to cover default/explicit IDs, validation, and duplicate registration behavior.
- Ran the module unit tests for `namastack-outbox-api` and `namastack-outbox-core`, and all modified/added tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f6a68f65c8326ab523f8dc4271681)