### PR TITLE
GH-427 use Spring bean names as IDs for lambda handlers

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
@@ -1,5 +1,6 @@
 package io.namastack.outbox.handler
 
+import io.namastack.outbox.handler.method.handler.OutboxHandlerMethod
 import io.namastack.outbox.handler.registry.OutboxFallbackHandlerRegistry
 import io.namastack.outbox.handler.registry.OutboxHandlerRegistry
 import io.namastack.outbox.handler.scanner.HandlerScanResult
@@ -9,6 +10,7 @@ import io.namastack.outbox.handler.scanner.handler.InterfaceHandlerScanner
 import io.namastack.outbox.retry.OutboxRetryPolicyRegistry
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.config.BeanPostProcessor
+import org.springframework.util.ClassUtils
 
 /**
  * Spring BeanPostProcessor that discovers and registers handlers with their fallbacks.
@@ -86,13 +88,21 @@ internal class OutboxHandlerBeanPostProcessor(
                 .forEach { policy -> retryPolicyRegistry.register(handler.id, policy) }
 
             // d. Register legacy alias if bean is an AOP proxy (backward compatibility)
-            if (AopUtils.isAopProxy(bean) && handler.id != handler.legacyId) {
+            if (shouldRegisterLegacyAlias(bean, handler)) {
                 registerLegacyAliases(handler.legacyId, result)
             }
         }
 
         return bean
     }
+
+    private fun shouldRegisterLegacyAlias(
+        bean: Any,
+        handler: OutboxHandlerMethod,
+    ): Boolean =
+        AopUtils.isAopProxy(bean) &&
+            !ClassUtils.isLambdaClass(AopUtils.getTargetClass(bean)) &&
+            handler.id != handler.legacyId
 
     /**
      * Registers legacy alias IDs in all registries for backward compatibility

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessor.kt
@@ -7,6 +7,7 @@ import io.namastack.outbox.handler.scanner.RetryPolicyScanner
 import io.namastack.outbox.handler.scanner.handler.AnnotatedHandlerScanner
 import io.namastack.outbox.handler.scanner.handler.InterfaceHandlerScanner
 import io.namastack.outbox.retry.OutboxRetryPolicyRegistry
+import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.config.BeanPostProcessor
 
 /**
@@ -52,9 +53,9 @@ internal class OutboxHandlerBeanPostProcessor(
      * Scans for handlers and their fallbacks, then registers them:
      * 1. Scan bean for handlers using all scanners
      * 2. Register handler in handler registry
-     * 3. Register legacy alias if bean is an AOP proxy (backward compatibility)
-     * 4. Register fallback (if present) with handler.id
-     * 5. Register retry policy for handler
+     * 3. Register fallback (if present) with handler.id
+     * 4. Register retry policy for handler
+     * 5. Register legacy alias if bean is an AOP proxy (backward compatibility)
      *
      * @param bean The newly instantiated bean
      * @param beanName The bean name in Spring context
@@ -65,7 +66,7 @@ internal class OutboxHandlerBeanPostProcessor(
         beanName: String,
     ): Any {
         // 1. Scan for all handlers and their fallbacks in this bean
-        val scanResults = handlerScanners.flatMap { it.scan(bean) }
+        val scanResults = handlerScanners.flatMap { it.scan(bean, beanName) }
 
         // 2. For each result: register handler + fallback + retry policy + legacy alias
         scanResults.forEach { result ->
@@ -85,7 +86,7 @@ internal class OutboxHandlerBeanPostProcessor(
                 .forEach { policy -> retryPolicyRegistry.register(handler.id, policy) }
 
             // d. Register legacy alias if bean is an AOP proxy (backward compatibility)
-            if (handler.id != handler.legacyId) {
+            if (AopUtils.isAopProxy(bean) && handler.id != handler.legacyId) {
                 registerLegacyAliases(handler.legacyId, result)
             }
         }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
@@ -19,14 +19,15 @@ abstract class BaseHandlerMethod(
     val method: Method,
 ) {
     /**
-     * Unique identifier for routing and tracking.
-     * Format: `ClassName#methodName(Type1,Type2,...)`
+     * Unique identifier for routing and tracking. Defaults to
+     * `ClassName#methodName(Type1,Type2,...)`; interface-based lambda handlers use their
+     * stable Spring bean name instead.
      */
-    val id: String = buildId()
+    var id: String = buildId()
+        internal set
 
     /**
-     * Builds unique ID from class name, method name, and parameter types.
-     * ID remains stable across restarts for persistent record association.
+     * Builds the default ID from class name, method name, and parameter types.
      */
     protected fun buildId(): String {
         val className = ReflectionUtils.getTargetClass(bean).name

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/AnnotatedHandlerScanner.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/AnnotatedHandlerScanner.kt
@@ -38,9 +38,15 @@ class AnnotatedHandlerScanner : HandlerScanner {
         )
 
     /**
-     * Scans bean for handler and fallback methods, matching them by payload type.
+     * Scans a bean for handler and fallback methods, matching them by payload type.
+     *
+     * @param bean The bean to scan
+     * @param beanName The bean's name in the Spring application context
      */
-    override fun scan(bean: Any): List<HandlerScanResult> {
+    override fun scan(
+        bean: Any,
+        beanName: String,
+    ): List<HandlerScanResult> {
         val fallbackMethods = getFallbackMethods(bean)
 
         return ReflectionUtils

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/HandlerScanner.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/HandlerScanner.kt
@@ -27,7 +27,11 @@ interface HandlerScanner {
      * both the handler and its optional fallback.
      *
      * @param bean The bean to scan for handlers
+     * @param beanName The bean's name in the Spring application context
      * @return List of discovered handler scan results (empty if no handlers found)
      */
-    fun scan(bean: Any): List<HandlerScanResult>
+    fun scan(
+        bean: Any,
+        beanName: String,
+    ): List<HandlerScanResult>
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScanner.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScanner.kt
@@ -8,7 +8,9 @@ import io.namastack.outbox.handler.method.fallback.factory.GenericFallbackHandle
 import io.namastack.outbox.handler.method.fallback.factory.TypedFallbackHandlerMethodFactory
 import io.namastack.outbox.handler.method.handler.factory.GenericHandlerMethodFactory
 import io.namastack.outbox.handler.method.handler.factory.TypedHandlerMethodFactory
+import io.namastack.outbox.handler.method.internal.ReflectionUtils
 import io.namastack.outbox.handler.scanner.HandlerScanResult
+import org.springframework.util.ClassUtils
 
 /**
  * Scanner that discovers handler implementations via interface inheritance.
@@ -42,11 +44,12 @@ class InterfaceHandlerScanner : HandlerScanner {
      * Algorithm:
      * 1. Check if bean implements OutboxTypedHandler<T> or OutboxHandler
      * 2. If not, return empty list (no handlers to register)
-     * 3. If OutboxTypedHandler<T>: Create typed handler
-     * 4. If bean also implements WithFallback variant: Create fallback and pair with handler
-     * 5. If OutboxHandler: Create generic handler
-     * 6. If bean also implements WithFallback variant: Create fallback and pair with handler
-     * 7. Return all discovered handler scan results
+     * 3. Use the Spring bean name as handler ID when the bean is a lambda
+     * 4. If OutboxTypedHandler<T>: Create typed handler
+     * 5. If bean also implements WithFallback variant: Create fallback and pair with handler
+     * 6. If OutboxHandler: Create generic handler
+     * 7. If bean also implements WithFallback variant: Create fallback and pair with handler
+     * 8. Return all discovered handler scan results
      *
      * Example:
      * ```kotlin
@@ -67,16 +70,23 @@ class InterfaceHandlerScanner : HandlerScanner {
      * → Returns: HandlerScanResult(handler, fallback=TypedFallbackHandlerMethod)
      *
      * @param bean The bean to scan for handler interface implementations
+     * @param beanName The bean's name, used as the stable ID for lambda handlers
      * @return List of discovered handler scan results
      */
-    override fun scan(bean: Any): List<HandlerScanResult> {
+    override fun scan(
+        bean: Any,
+        beanName: String,
+    ): List<HandlerScanResult> {
         if (bean !is OutboxTypedHandler<*> && bean !is OutboxHandler) return emptyList()
 
         val results = mutableListOf<HandlerScanResult>()
+        val handlerIdOverride = getHandlerIdOverride(bean, beanName)
 
         // Register typed handler if bean implements OutboxTypedHandler<T>
         if (bean is OutboxTypedHandler<*>) {
             val handler = typedHandlerFactory.createFromInterface(bean)
+            handlerIdOverride?.let { handler.id = it }
+
             val fallback =
                 if (bean is OutboxTypedHandlerWithFallback<*>) {
                     typedFallbackFactory.createFromInterface(bean)
@@ -89,6 +99,8 @@ class InterfaceHandlerScanner : HandlerScanner {
         // Register generic handler if bean implements OutboxHandler
         if (bean is OutboxHandler) {
             val handler = genericHandlerFactory.createFromInterface(bean)
+            handlerIdOverride?.let { handler.id = it }
+
             val fallback =
                 if (bean is OutboxHandlerWithFallback) {
                     genericFallbackFactory.createFromInterface(bean)
@@ -100,4 +112,9 @@ class InterfaceHandlerScanner : HandlerScanner {
 
         return results
     }
+
+    private fun getHandlerIdOverride(
+        bean: Any,
+        beanName: String,
+    ): String? = beanName.takeIf { ClassUtils.isLambdaClass(ReflectionUtils.getTargetClass(bean)) }
 }

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/LambdaOutboxHandlerFactory.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/LambdaOutboxHandlerFactory.java
@@ -1,0 +1,10 @@
+package io.namastack.outbox.handler;
+
+final class LambdaOutboxHandlerFactory {
+
+    private LambdaOutboxHandlerFactory() {}
+
+    static OutboxHandler create() {
+        return (payload, metadata) -> {};
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/scanner/handler/LambdaOutboxHandlerFactory.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/scanner/handler/LambdaOutboxHandlerFactory.java
@@ -1,0 +1,12 @@
+package io.namastack.outbox.handler.scanner.handler;
+
+import io.namastack.outbox.handler.OutboxHandler;
+
+final class LambdaOutboxHandlerFactory {
+
+    private LambdaOutboxHandlerFactory() {}
+
+    static OutboxHandler create() {
+        return (payload, metadata) -> {};
+    }
+}

--- a/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/scanner/handler/LambdaOutboxHandlerFactory.java
+++ b/namastack-outbox-core/src/test/java/io/namastack/outbox/handler/scanner/handler/LambdaOutboxHandlerFactory.java
@@ -1,12 +1,17 @@
 package io.namastack.outbox.handler.scanner.handler;
 
 import io.namastack.outbox.handler.OutboxHandler;
+import io.namastack.outbox.handler.OutboxTypedHandler;
 
 final class LambdaOutboxHandlerFactory {
 
     private LambdaOutboxHandlerFactory() {}
 
     static OutboxHandler create() {
+        return (payload, metadata) -> {};
+    }
+
+    static OutboxTypedHandler<String> createTyped() {
         return (payload, metadata) -> {};
     }
 }

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
@@ -66,7 +66,7 @@ class OutboxHandlerBeanPostProcessorTest {
     }
 
     @Test
-    fun `does not register generated lambda ID as legacy alias`() {
+    fun `does not register generated lambda ID as legacy alias for non-proxied lambda`() {
         val realHandlerRegistry = OutboxHandlerRegistry()
         val processor =
             OutboxHandlerBeanPostProcessor(
@@ -77,6 +77,25 @@ class OutboxHandlerBeanPostProcessorTest {
         val lambda = LambdaOutboxHandlerFactory.create()
 
         processor.postProcessAfterInitialization(lambda, "modulithEventExternalizer")
+
+        val handler = requireNotNull(realHandlerRegistry.getHandlerById("modulithEventExternalizer"))
+        assertThat(realHandlerRegistry.getHandlerById(handler.legacyId)).isNull()
+    }
+
+    @Test
+    fun `does not register generated proxy ID as legacy alias for proxied lambda`() {
+        val realHandlerRegistry = OutboxHandlerRegistry()
+        val processor =
+            OutboxHandlerBeanPostProcessor(
+                realHandlerRegistry,
+                OutboxFallbackHandlerRegistry(),
+                retryPolicyRegistry,
+            )
+        val proxyFactory = ProxyFactory(LambdaOutboxHandlerFactory.create())
+        proxyFactory.addAdvice(MethodInterceptor { it.proceed() })
+        val proxiedLambda = proxyFactory.proxy
+
+        processor.postProcessAfterInitialization(proxiedLambda, "modulithEventExternalizer")
 
         val handler = requireNotNull(realHandlerRegistry.getHandlerById("modulithEventExternalizer"))
         assertThat(realHandlerRegistry.getHandlerById(handler.legacyId)).isNull()

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/OutboxHandlerBeanPostProcessorTest.kt
@@ -17,9 +17,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.aop.framework.ProxyFactory
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import kotlin.reflect.KClass
 
 @DisplayName("OutboxHandlerBeanPostProcessor")
@@ -66,6 +63,23 @@ class OutboxHandlerBeanPostProcessorTest {
         verify(exactly = 1) { handlerRegistry.register(any()) }
         verify(exactly = 0) { fallbackHandlerRegistry.register(any(), any()) }
         verify(exactly = 0) { retryPolicyRegistry.register(any(), any()) }
+    }
+
+    @Test
+    fun `does not register generated lambda ID as legacy alias`() {
+        val realHandlerRegistry = OutboxHandlerRegistry()
+        val processor =
+            OutboxHandlerBeanPostProcessor(
+                realHandlerRegistry,
+                OutboxFallbackHandlerRegistry(),
+                retryPolicyRegistry,
+            )
+        val lambda = LambdaOutboxHandlerFactory.create()
+
+        processor.postProcessAfterInitialization(lambda, "modulithEventExternalizer")
+
+        val handler = requireNotNull(realHandlerRegistry.getHandlerById("modulithEventExternalizer"))
+        assertThat(realHandlerRegistry.getHandlerById(handler.legacyId)).isNull()
     }
 
     @Test
@@ -325,7 +339,6 @@ class OutboxHandlerBeanPostProcessorTest {
     @Nested
     @DisplayName("Legacy alias registration for CGLIB proxies")
     inner class LegacyAliasTests {
-        private val clock = Clock.fixed(Instant.parse("2025-09-25T10:00:00Z"), ZoneOffset.UTC)
         private val realHandlerRegistry = OutboxHandlerRegistry()
         private val realFallbackRegistry = OutboxFallbackHandlerRegistry()
 

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScannerTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScannerTest.kt
@@ -1,0 +1,27 @@
+package io.namastack.outbox.handler.scanner.handler
+
+import io.namastack.outbox.HandlerBeanFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class InterfaceHandlerScannerTest {
+    private val scanner = InterfaceHandlerScanner()
+
+    @Test
+    fun `uses bean name as handler ID for lambda`() {
+        val handler = scanner.scan(LambdaOutboxHandlerFactory.create(), "modulithEventExternalizer").single().handler
+
+        assertThat(handler.id).isEqualTo("modulithEventExternalizer")
+    }
+
+    @Test
+    fun `keeps generated handler ID for regular interface implementation`() {
+        val bean = HandlerBeanFactory.createGenericInterfaceHandler()
+        val handler = scanner.scan(bean, "genericInterfaceHandler").single().handler
+
+        assertThat(handler.id)
+            .startsWith(bean::class.java.name)
+            .contains("#handle(")
+            .isNotEqualTo("genericInterfaceHandler")
+    }
+}

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScannerTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScannerTest.kt
@@ -15,6 +15,13 @@ class InterfaceHandlerScannerTest {
     }
 
     @Test
+    fun `uses bean name as handler ID for typed lambda`() {
+        val handler = scanner.scan(LambdaOutboxHandlerFactory.createTyped(), "typedEventExternalizer").single().handler
+
+        assertThat(handler.id).isEqualTo("typedEventExternalizer")
+    }
+
+    @Test
     fun `keeps generated handler ID for regular interface implementation`() {
         val bean = HandlerBeanFactory.createGenericInterfaceHandler()
         val handler = scanner.scan(bean, "genericInterfaceHandler").single().handler


### PR DESCRIPTION
Detect interface-based lambda handlers and use their Spring bean name as the stable handler ID instead of the generated JVM lambda class name.

Restrict legacy alias registration to Spring AOP proxies and add regression coverage for lambda and regular interface handler IDs.