### PR TITLE
Make BaseHandlerMethod handler id immutable via constructor

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/BaseHandlerMethod.kt
@@ -17,14 +17,14 @@ import java.lang.reflect.Method
 abstract class BaseHandlerMethod(
     val bean: Any,
     val method: Method,
+    id: String? = null,
 ) {
     /**
      * Unique identifier for routing and tracking. Defaults to
      * `ClassName#methodName(Type1,Type2,...)`; interface-based lambda handlers use their
      * stable Spring bean name instead.
      */
-    var id: String = buildId()
-        internal set
+    val id: String = id ?: buildId()
 
     /**
      * Builds the default ID from class name, method name, and parameter types.

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerAnnotationMethod.kt
@@ -17,7 +17,8 @@ import java.lang.reflect.Method
 class GenericHandlerAnnotationMethod(
     bean: Any,
     method: Method,
-) : GenericHandlerMethod(bean, method) {
+    id: String? = null,
+) : GenericHandlerMethod(bean, method, id) {
     /**
      * Determines whether this handler should be scheduled for the given payload.
      */

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethod.kt
@@ -18,7 +18,8 @@ import java.lang.reflect.Method
 class GenericHandlerInterfaceMethod(
     bean: OutboxHandler,
     method: Method,
-) : GenericHandlerMethod(bean, method) {
+    id: String? = null,
+) : GenericHandlerMethod(bean, method, id) {
     /**
      * Determines whether this handler should be scheduled for the given payload.
      */

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerMethod.kt
@@ -17,7 +17,8 @@ import java.lang.reflect.Method
 sealed class GenericHandlerMethod(
     bean: Any,
     method: Method,
-) : OutboxHandlerMethod(bean, method) {
+    id: String? = null,
+) : OutboxHandlerMethod(bean, method, id) {
     /**
      * Determines whether this handler should be scheduled for the given payload.
      */

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/OutboxHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/OutboxHandlerMethod.kt
@@ -10,6 +10,7 @@ import java.lang.reflect.Method
  *
  * @param bean Bean containing the handler method
  * @param method Handler method for reflection
+ * @param id ID for the handler method
  *
  * @author Roland Beisel
  * @since 1.0.0
@@ -17,4 +18,5 @@ import java.lang.reflect.Method
 sealed class OutboxHandlerMethod(
     bean: Any,
     method: Method,
-) : BaseHandlerMethod(bean, method)
+    id: String? = null,
+) : BaseHandlerMethod(bean, method, id)

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/TypedHandlerMethod.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/TypedHandlerMethod.kt
@@ -20,7 +20,8 @@ import kotlin.reflect.KClass
 class TypedHandlerMethod(
     bean: Any,
     method: Method,
-) : OutboxHandlerMethod(bean, method) {
+    id: String? = null,
+) : OutboxHandlerMethod(bean, method, id) {
     /** Payload type extracted from method's first parameter. */
     internal val paramType: KClass<*>
         get() = method.parameterTypes.first().kotlin

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactory.kt
@@ -42,8 +42,8 @@ class GenericHandlerMethodFactory : OutboxHandlerMethodFactory {
     /**
      * Creates generic handler from OutboxHandler interface.
      */
-    fun createFromInterface(bean: OutboxHandler): GenericHandlerMethod {
+    fun createFromInterface(bean: OutboxHandler, handlerId: String?): GenericHandlerMethod {
         val method = ReflectionUtils.findMethod(bean, "handle", 2)
-        return GenericHandlerInterfaceMethod(bean, method)
+        return GenericHandlerInterfaceMethod(bean, method, handlerId)
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactory.kt
@@ -42,7 +42,10 @@ class GenericHandlerMethodFactory : OutboxHandlerMethodFactory {
     /**
      * Creates generic handler from OutboxHandler interface.
      */
-    fun createFromInterface(bean: OutboxHandler, handlerId: String?): GenericHandlerMethod {
+    fun createFromInterface(
+        bean: OutboxHandler,
+        handlerId: String?,
+    ): GenericHandlerMethod {
         val method = ReflectionUtils.findMethod(bean, "handle", 2)
         return GenericHandlerInterfaceMethod(bean, method, handlerId)
     }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactory.kt
@@ -48,7 +48,10 @@ class TypedHandlerMethodFactory : OutboxHandlerMethodFactory {
     /**
      * Creates typed handler from OutboxTypedHandler interface.
      */
-    fun createFromInterface(bean: OutboxTypedHandler<*>, handlerId: String?): TypedHandlerMethod {
+    fun createFromInterface(
+        bean: OutboxTypedHandler<*>,
+        handlerId: String?,
+    ): TypedHandlerMethod {
         val method = ReflectionUtils.findMethod(bean, "handle", 2)
         return TypedHandlerMethod(bean, method, handlerId)
     }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactory.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactory.kt
@@ -48,8 +48,8 @@ class TypedHandlerMethodFactory : OutboxHandlerMethodFactory {
     /**
      * Creates typed handler from OutboxTypedHandler interface.
      */
-    fun createFromInterface(bean: OutboxTypedHandler<*>): TypedHandlerMethod {
+    fun createFromInterface(bean: OutboxTypedHandler<*>, handlerId: String?): TypedHandlerMethod {
         val method = ReflectionUtils.findMethod(bean, "handle", 2)
-        return TypedHandlerMethod(bean, method)
+        return TypedHandlerMethod(bean, method, handlerId)
     }
 }

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScanner.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/handler/scanner/handler/InterfaceHandlerScanner.kt
@@ -80,12 +80,11 @@ class InterfaceHandlerScanner : HandlerScanner {
         if (bean !is OutboxTypedHandler<*> && bean !is OutboxHandler) return emptyList()
 
         val results = mutableListOf<HandlerScanResult>()
-        val handlerIdOverride = getHandlerIdOverride(bean, beanName)
+        val handlerId = getHandlerIdOverride(bean, beanName)
 
         // Register typed handler if bean implements OutboxTypedHandler<T>
         if (bean is OutboxTypedHandler<*>) {
-            val handler = typedHandlerFactory.createFromInterface(bean)
-            handlerIdOverride?.let { handler.id = it }
+            val handler = typedHandlerFactory.createFromInterface(bean, handlerId)
 
             val fallback =
                 if (bean is OutboxTypedHandlerWithFallback<*>) {
@@ -98,8 +97,7 @@ class InterfaceHandlerScanner : HandlerScanner {
 
         // Register generic handler if bean implements OutboxHandler
         if (bean is OutboxHandler) {
-            val handler = genericHandlerFactory.createFromInterface(bean)
-            handlerIdOverride?.let { handler.id = it }
+            val handler = genericHandlerFactory.createFromInterface(bean, handlerId)
 
             val fallback =
                 if (bean is OutboxHandlerWithFallback) {

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/GenericHandlerInterfaceMethodTest.kt
@@ -25,6 +25,36 @@ class GenericHandlerInterfaceMethodTest {
         assertThat(supported).isFalse()
     }
 
+    @Test
+    fun `generates id when null`() {
+        val bean = ConditionalGenericHandler(supported = true)
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                Any::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+        val handler = GenericHandlerInterfaceMethod(bean, method)
+
+        assertThat(handler.id)
+            .startsWith(bean::class.java.name)
+            .contains("#handle(")
+    }
+
+    @Test
+    fun `uses provided id when not null`() {
+        val bean = ConditionalGenericHandler(supported = true)
+        val method =
+            bean::class.java.getMethod(
+                "handle",
+                Any::class.java,
+                OutboxRecordMetadata::class.java,
+            )
+        val handler = GenericHandlerInterfaceMethod(bean, method, "custom-id")
+
+        assertThat(handler.id).isEqualTo("custom-id")
+    }
+
     private fun metadata() =
         OutboxRecordMetadata(
             key = "test-key",

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactoryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/factory/GenericHandlerMethodFactoryTest.kt
@@ -178,7 +178,7 @@ class GenericHandlerMethodFactoryTest {
         fun `should create generic handler from OutboxHandler implementation`() {
             val bean = TestHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             assertThat(result).isInstanceOf(GenericHandlerMethod::class.java)
             assertThat(result.bean).isSameAs(bean)
@@ -188,7 +188,7 @@ class GenericHandlerMethodFactoryTest {
         fun `should extract handle method from interface`() {
             val bean = TestHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             assertThat(result.method.name).isEqualTo("handle")
             assertThat(result.method.parameterCount).isEqualTo(2)
@@ -198,7 +198,7 @@ class GenericHandlerMethodFactoryTest {
         fun `should verify parameter types from interface`() {
             val bean = TestHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             val parameterTypes = result.method.parameterTypes
             assertThat(parameterTypes[0]).isEqualTo(Any::class.java)
@@ -210,12 +210,36 @@ class GenericHandlerMethodFactoryTest {
             val bean1 = TestHandlerImpl()
             val bean2 = AnotherTestHandlerImpl()
 
-            val handler1 = factory.createFromInterface(bean1)
-            val handler2 = factory.createFromInterface(bean2)
+            val handler1 = factory.createFromInterface(bean1, null)
+            val handler2 = factory.createFromInterface(bean2, null)
 
             assertThat(handler1.bean).isSameAs(bean1)
             assertThat(handler2.bean).isSameAs(bean2)
             assertThat(handler1.id).isNotEqualTo(handler2.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("createFromInterface() handler ID override")
+    inner class CreateFromInterfaceIdOverrideTests {
+        @Test
+        fun `should fall back to generated id when handlerId is null`() {
+            val bean = TestHandlerImpl()
+
+            val result = factory.createFromInterface(bean, null)
+
+            assertThat(result.id)
+                .startsWith(bean::class.java.name)
+                .matches(".*#.*\\(.*\\)")
+        }
+
+        @Test
+        fun `should use provided handlerId as id`() {
+            val bean = TestHandlerImpl()
+
+            val result = factory.createFromInterface(bean, "custom-id")
+
+            assertThat(result.id).isEqualTo("custom-id")
         }
     }
 

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactoryTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/handler/method/handler/factory/TypedHandlerMethodFactoryTest.kt
@@ -237,7 +237,7 @@ class TypedHandlerMethodFactoryTest {
         fun `should create typed handler from OutboxTypedHandler String implementation`() {
             val bean = StringHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             assertThat(result).isInstanceOf(TypedHandlerMethod::class.java)
             assertThat(result.bean).isSameAs(bean)
@@ -248,7 +248,7 @@ class TypedHandlerMethodFactoryTest {
         fun `should create typed handler from OutboxTypedHandler TestPayload implementation`() {
             val bean = PayloadHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             assertThat(result).isInstanceOf(TypedHandlerMethod::class.java)
             assertThat(result.method.parameterTypes.first()).isEqualTo(TestPayload::class.java)
@@ -258,7 +258,7 @@ class TypedHandlerMethodFactoryTest {
         fun `should extract handle method from interface implementation`() {
             val bean = StringHandlerImpl()
 
-            val result = factory.createFromInterface(bean)
+            val result = factory.createFromInterface(bean, null)
 
             assertThat(result.method.name).isEqualTo("handle")
             assertThat(result.method.parameterCount).isEqualTo(2)
@@ -269,10 +269,34 @@ class TypedHandlerMethodFactoryTest {
             val bean1 = StringHandlerImpl()
             val bean2 = PayloadHandlerImpl()
 
-            val handler1 = factory.createFromInterface(bean1)
-            val handler2 = factory.createFromInterface(bean2)
+            val handler1 = factory.createFromInterface(bean1, null)
+            val handler2 = factory.createFromInterface(bean2, null)
 
             assertThat(handler1.id).isNotEqualTo(handler2.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("createFromInterface() handler ID override")
+    inner class CreateFromInterfaceIdOverrideTests {
+        @Test
+        fun `should fall back to generated id when handlerId is null`() {
+            val bean = StringHandlerImpl()
+
+            val result = factory.createFromInterface(bean, null)
+
+            assertThat(result.id)
+                .startsWith(bean::class.java.name)
+                .matches(".*#.*\\(.*\\)")
+        }
+
+        @Test
+        fun `should use provided handlerId as id`() {
+            val bean = StringHandlerImpl()
+
+            val result = factory.createFromInterface(bean, "custom-id")
+
+            assertThat(result.id).isEqualTo("custom-id")
         }
     }
 


### PR DESCRIPTION
Refactors handler id assignment to be immutable. The id is now provided
through the `BaseHandlerMethod` constructor rather than being set after
construction.

Reference: #428 