### PR TITLE
Support OutboxRecord ID Generator Injection (#435)

### DIFF
--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxRecord.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxRecord.kt
@@ -173,10 +173,20 @@ class OutboxRecord<T> internal constructor(
      * Builder class for creating new OutboxRecord instances.
      */
     class Builder<T> {
+        private var id: String? = null
         private var key: String? = null
         private var payload: T? = null
         private var context: Map<String, String>? = null
         private var handlerId: String? = null
+
+        /**
+         * Sets the record identifier for an internally created record.
+         *
+         * The public Builder API continues to generate a random UUID when this is not
+         * set. This internal path allows [OutboxService] to inject its configured
+         * identifier generator without changing the Builder's public contract.
+         */
+        internal fun id(id: String) = apply { this.id = id }
 
         /**
          * Sets the record key for the outbox record.
@@ -217,8 +227,9 @@ class OutboxRecord<T> internal constructor(
          * @return A new OutboxRecord instance
          */
         fun build(clock: Clock): OutboxRecord<T> {
-            val id = UUID.randomUUID().toString()
-            val rk = key ?: id
+            val generatedId = id ?: UUID.randomUUID().toString()
+            require(generatedId.isNotBlank()) { "outbox record id must not be blank" }
+            val rk = key ?: generatedId
             val pl = payload ?: error("payload must be set")
             val ctx = context ?: emptyMap()
             val hId = handlerId ?: error("handlerId must be set")
@@ -227,7 +238,7 @@ class OutboxRecord<T> internal constructor(
             val partition = PartitionHasher.getPartitionForRecordKey(rk)
 
             return OutboxRecord(
-                id = id,
+                id = generatedId,
                 status = NEW,
                 key = rk,
                 payload = pl,

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxRecordIdGenerator.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxRecordIdGenerator.kt
@@ -1,0 +1,32 @@
+package io.namastack.outbox
+
+import java.util.UUID
+
+/**
+ * Generates identifiers for newly scheduled outbox records.
+ *
+ * Implementations must be thread-safe and return a non-blank, unique identifier for
+ * every invocation, including concurrent invocations. The generated identifier is
+ * used only as [OutboxRecord.id]; it does not control the record key or partition.
+ *
+ * @author Hyeonseok Song
+ * @since 1.8.1
+ */
+fun interface OutboxRecordIdGenerator {
+    /**
+     * Generates an identifier for one newly scheduled outbox record.
+     *
+     * @return a non-blank identifier that is unique for this invocation
+     */
+    fun generate(): String
+}
+
+/**
+ * Default [OutboxRecordIdGenerator] that creates random UUID identifiers.
+ *
+ * @author Hyeonseok Song
+ * @since 1.8.1
+ */
+class RandomUuidOutboxRecordIdGenerator : OutboxRecordIdGenerator {
+    override fun generate(): String = UUID.randomUUID().toString()
+}

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxService.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/OutboxService.kt
@@ -59,6 +59,7 @@ import kotlin.reflect.KClass
  * @param handlerRegistry Registry of all discovered handler methods
  * @param outboxRecordRepository Repository for persisting records
  * @param clock Clock for timestamp generation
+ * @param outboxRecordIdGenerator Generator for newly scheduled record identifiers
  *
  * @author Roland Beisel
  * @since 0.4.0
@@ -69,7 +70,26 @@ class OutboxService(
     private val handlerRegistry: OutboxHandlerRegistry,
     private val outboxRecordRepository: OutboxRecordRepository,
     private val clock: Clock,
+    private val outboxRecordIdGenerator: OutboxRecordIdGenerator,
 ) : Outbox {
+    /**
+     * Creates an [OutboxService] using the default random UUID identifier generator.
+     *
+     * This constructor preserves the existing Kotlin and Java construction API.
+     */
+    constructor(
+        contextCollector: OutboxContextCollector,
+        handlerRegistry: OutboxHandlerRegistry,
+        outboxRecordRepository: OutboxRecordRepository,
+        clock: Clock,
+    ) : this(
+        contextCollector = contextCollector,
+        handlerRegistry = handlerRegistry,
+        outboxRecordRepository = outboxRecordRepository,
+        clock = clock,
+        outboxRecordIdGenerator = RandomUuidOutboxRecordIdGenerator(),
+    )
+
     /**
      * Schedules a record with an explicit key and additional context for processing.
      *
@@ -178,6 +198,7 @@ class OutboxService(
             val outboxRecord =
                 OutboxRecord
                     .Builder<Any>()
+                    .id(outboxRecordIdGenerator.generate())
                     .key(key)
                     .payload(payload)
                     .context(context)

--- a/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
+++ b/namastack-outbox-core/src/main/kotlin/io/namastack/outbox/config/OutboxCoreInfrastructureAutoConfiguration.kt
@@ -3,8 +3,10 @@ package io.namastack.outbox.config
 import io.micrometer.observation.ObservationRegistry
 import io.namastack.outbox.Outbox
 import io.namastack.outbox.OutboxProperties
+import io.namastack.outbox.OutboxRecordIdGenerator
 import io.namastack.outbox.OutboxRecordRepository
 import io.namastack.outbox.OutboxService
+import io.namastack.outbox.RandomUuidOutboxRecordIdGenerator
 import io.namastack.outbox.context.OutboxContextCollector
 import io.namastack.outbox.context.OutboxContextProvider
 import io.namastack.outbox.handler.OutboxHandlerBeanPostProcessor
@@ -119,17 +121,23 @@ class OutboxCoreInfrastructureAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun outboxRecordIdGenerator(): OutboxRecordIdGenerator = RandomUuidOutboxRecordIdGenerator()
+
+    @Bean
+    @ConditionalOnMissingBean
     fun outbox(
         outboxContextCollector: OutboxContextCollector,
         handlerRegistry: OutboxHandlerRegistry,
         recordRepository: OutboxRecordRepository,
         clock: Clock,
+        outboxRecordIdGenerator: OutboxRecordIdGenerator,
     ): Outbox =
         OutboxService(
             contextCollector = outboxContextCollector,
             handlerRegistry = handlerRegistry,
             outboxRecordRepository = recordRepository,
             clock = clock,
+            outboxRecordIdGenerator = outboxRecordIdGenerator,
         )
 
     companion object {

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxCoreAutoConfigurationTest.kt
@@ -86,6 +86,32 @@ class OutboxCoreAutoConfigurationTest {
         }
 
         @Test
+        fun `creates random UUID record id generator by default`() {
+            contextRunner
+                .withUserConfiguration(MinimalTestConfig::class.java)
+                .run { context ->
+                    assertThat(context).hasSingleBean(OutboxRecordIdGenerator::class.java)
+                    assertThat(context.getBean<OutboxRecordIdGenerator>())
+                        .isInstanceOf(RandomUuidOutboxRecordIdGenerator::class.java)
+                }
+        }
+
+        @Test
+        fun `uses custom record id generator and injects it into outbox service`() {
+            contextRunner
+                .withUserConfiguration(ConfigWithCustomOutboxRecordIdGenerator::class.java)
+                .run { context ->
+                    val generator = context.getBean<OutboxRecordIdGenerator>()
+                    assertThat(generator).isSameAs(ConfigWithCustomOutboxRecordIdGenerator.generator)
+
+                    val outboxService = context.getBean<Outbox>() as OutboxService
+                    val injectedGenerator =
+                        ReflectionTestUtils.getField(outboxService, "outboxRecordIdGenerator")
+                    assertThat(injectedGenerator).isSameAs(generator)
+                }
+        }
+
+        @Test
         fun `creates default instance registry`() {
             contextRunner
                 .withUserConfiguration(MinimalTestConfig::class.java)
@@ -513,6 +539,16 @@ class OutboxCoreAutoConfigurationTest {
     private class ConfigWithCustomClock : MinimalTestConfig() {
         @Bean
         fun clock(): Clock = Clock.fixed(Instant.parse("2020-02-02T00:00:00Z"), ZoneId.systemDefault())
+    }
+
+    @Configuration
+    private class ConfigWithCustomOutboxRecordIdGenerator : MinimalTestConfig() {
+        companion object {
+            val generator = OutboxRecordIdGenerator { "custom-id" }
+        }
+
+        @Bean
+        fun outboxRecordIdGenerator(): OutboxRecordIdGenerator = generator
     }
 
     @Configuration

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxRecordTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxRecordTest.kt
@@ -3,6 +3,7 @@ package io.namastack.outbox
 import io.namastack.outbox.OutboxRecordTestFactory.outboxRecord
 import io.namastack.outbox.partition.PartitionHasher
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -433,6 +434,53 @@ class OutboxRecordTest {
 
             assertThat(record.id).isNotEmpty()
             assertThat(record.id).isNotEqualTo("test-key")
+            assertThat(record.id)
+                .matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+        }
+
+        @Test
+        fun `should preserve internally provided id on build`() {
+            val record =
+                OutboxRecord
+                    .Builder<String>()
+                    .id("provided-id")
+                    .key("test-key")
+                    .payload("test-payload")
+                    .handlerId("TestHandler#handle(java.lang.String)")
+                    .build(clock)
+
+            assertThat(record.id).isEqualTo("provided-id")
+        }
+
+        @Test
+        fun `should reject blank internally provided id`() {
+            assertThatThrownBy {
+                OutboxRecord
+                    .Builder<String>()
+                    .id(" ")
+                    .key("test-key")
+                    .payload("test-payload")
+                    .handlerId("TestHandler#handle(java.lang.String)")
+                    .build(clock)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("outbox record id must not be blank")
+        }
+
+        @Test
+        fun `should keep key and partition independent from internally provided id`() {
+            val key = "order-123"
+            val record =
+                OutboxRecord
+                    .Builder<String>()
+                    .id("provided-id")
+                    .key(key)
+                    .payload("test-payload")
+                    .handlerId("TestHandler#handle(java.lang.String)")
+                    .build(clock)
+
+            assertThat(record.id).isEqualTo("provided-id")
+            assertThat(record.key).isEqualTo(key)
+            assertThat(record.partition).isEqualTo(PartitionHasher.getPartitionForRecordKey(key))
         }
 
         @Test

--- a/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxServiceTest.kt
+++ b/namastack-outbox-core/src/test/kotlin/io/namastack/outbox/OutboxServiceTest.kt
@@ -8,7 +8,9 @@ import io.namastack.outbox.context.OutboxContextCollector
 import io.namastack.outbox.handler.method.handler.GenericHandlerMethod
 import io.namastack.outbox.handler.method.handler.TypedHandlerMethod
 import io.namastack.outbox.handler.registry.OutboxHandlerRegistry
+import io.namastack.outbox.partition.PartitionHasher
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -75,6 +77,70 @@ class OutboxServiceTest {
             assertThat(recordSlots).hasSize(2)
             assertThat(recordSlots[0].handlerId).isEqualTo("handler1")
             assertThat(recordSlots[1].handlerId).isEqualTo("handler2")
+        }
+
+        @Test
+        fun `should generate one id per handler without changing key partition or payload`() {
+            val key = "test-key"
+            val payload = TestPayload("test-id")
+            val context = mapOf("key1" to "value1")
+            val handler1 = createTypedMockHandler("handler1")
+            val handler2 = createTypedMockHandler("handler2")
+            val idGenerator = mockk<OutboxRecordIdGenerator>()
+            val recordSlots = mutableListOf<OutboxRecord<Any>>()
+            val service =
+                OutboxService(
+                    contextCollector = contextCollector,
+                    handlerRegistry = handlerRegistry,
+                    outboxRecordRepository = outboxRecordRepository,
+                    clock = clock,
+                    outboxRecordIdGenerator = idGenerator,
+                )
+
+            every { idGenerator.generate() } returnsMany listOf("id-1", "id-2")
+            every { contextCollector.collectContext() } returns emptyMap()
+            every { handlerRegistry.getHandlersForPayloadType(TestPayload::class) } returns listOf(handler1, handler2)
+            every { handlerRegistry.getGenericHandlers(payload, any()) } returns emptyList()
+            every { outboxRecordRepository.save(capture(recordSlots)) } answers { recordSlots.last() }
+
+            service.schedule(payload, key, context)
+
+            assertThat(recordSlots.map { it.id }).containsExactly("id-1", "id-2")
+            assertThat(recordSlots.map { it.handlerId }).containsExactly("handler1", "handler2")
+            assertThat(recordSlots.map { it.key }).containsExactly(key, key)
+            assertThat(recordSlots.map { it.partition })
+                .containsExactly(
+                    PartitionHasher.getPartitionForRecordKey(key),
+                    PartitionHasher.getPartitionForRecordKey(key),
+                )
+            assertThat(recordSlots.map { it.payload }).containsExactly(payload, payload)
+            verify(exactly = 2) { idGenerator.generate() }
+        }
+
+        @Test
+        fun `should reject blank generated id before saving the record`() {
+            val key = "test-key"
+            val payload = TestPayload("test-id")
+            val handler = createTypedMockHandler("handler1")
+            val idGenerator = mockk<OutboxRecordIdGenerator>()
+            val service =
+                OutboxService(
+                    contextCollector = contextCollector,
+                    handlerRegistry = handlerRegistry,
+                    outboxRecordRepository = outboxRecordRepository,
+                    clock = clock,
+                    outboxRecordIdGenerator = idGenerator,
+                )
+
+            every { idGenerator.generate() } returns " "
+            every { contextCollector.collectContext() } returns emptyMap()
+            every { handlerRegistry.getHandlersForPayloadType(TestPayload::class) } returns listOf(handler)
+            every { handlerRegistry.getGenericHandlers(payload, any()) } returns emptyList()
+
+            assertThatThrownBy { service.schedule(payload, key) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("outbox record id must not be blank")
+            verify(exactly = 0) { outboxRecordRepository.save(any() as OutboxRecord<Any>) }
         }
 
         @Test

--- a/namastack-outbox-docs/docs/reference/scheduling.md
+++ b/namastack-outbox-docs/docs/reference/scheduling.md
@@ -75,6 +75,43 @@ public class OrderService {
 </TabItem>
 </Tabs>
 
+## Custom Outbox Record ID Generator
+
+Spring Boot uses `RandomUuidOutboxRecordIdGenerator` by default, preserving the existing random UUID behavior. To use UUIDv7, ULID, or an application-specific generator, register an `OutboxRecordIdGenerator` bean:
+
+<Tabs>
+<TabItem value="kotlin" label="Kotlin">
+
+```kotlin
+@Configuration
+class OutboxIdConfiguration(
+    private val applicationIdGenerator: ApplicationIdGenerator
+) {
+    @Bean
+    fun outboxRecordIdGenerator(): OutboxRecordIdGenerator =
+        OutboxRecordIdGenerator { applicationIdGenerator.generate() }
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+@Configuration
+public class OutboxIdConfiguration {
+    @Bean
+    public OutboxRecordIdGenerator outboxRecordIdGenerator(
+            ApplicationIdGenerator applicationIdGenerator) {
+        return applicationIdGenerator::generate;
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The generator is called once for every handler record created by `OutboxService`. Implementations must be thread-safe and return a non-blank, unique value for each invocation. The generated value affects only `OutboxRecord.id`; an explicit `key`, automatic key generation, and partition assignment are unchanged. Blank values are rejected before repository persistence. Cross-instance uniqueness remains the responsibility of the generator and the database primary key.
+
 ### Record Lifecycle
 
 Records go through the following states:


### PR DESCRIPTION
Fixes #435

## Summary

This PR adds an extension point for injecting the generation strategy used for `OutboxRecord.id`. The default behavior remains unchanged and continues to use random UUIDs, while applications can choose UUIDv7, ULID, or an application-specific generator through a Spring bean.

## Changes

- Added the public `OutboxRecordIdGenerator` fun interface to the core module
- Added the default `RandomUuidOutboxRecordIdGenerator` implementation
- Injected the generator into `OutboxService` and call `generate()` exactly once for each handler record
- Preserved the existing four-argument `OutboxService` constructor by delegating to the default UUID generator
- Preserved the public no-argument `OutboxRecord.Builder` API and its random UUID behavior for direct callers
- Reject blank IDs immediately, before repository persistence
- Added a default generator bean to Spring Boot auto-configuration, with support for overriding it with a custom bean
- Kept `record_key` and partitioning behavior unchanged
- Did not modify JPA/JDBC/Mongo entities, repositories, schemas, or migrations

## API Usage

### Kotlin

```kotlin
@Configuration
class OutboxIdConfiguration(
    private val uuidV7Generator: UuidV7Generator,
) {
    @Bean
    fun outboxRecordIdGenerator(): OutboxRecordIdGenerator =
        OutboxRecordIdGenerator { uuidV7Generator.generate().toString() }
}
```

### Java

```java
@Configuration
public class OutboxIdConfiguration {
    @Bean
    public OutboxRecordIdGenerator outboxRecordIdGenerator(
            ApplicationIdGenerator applicationIdGenerator) {
        return applicationIdGenerator::generate;
    }
}
```

Implementations must be thread-safe and return a non-blank, unique value for every invocation. Final cross-instance collision protection remains the responsibility of the existing database primary key.

## Validation

- [x] `./gradlew :namastack-outbox-core:test --tests 'io.namastack.outbox.OutboxRecordTest' --tests 'io.namastack.outbox.OutboxServiceTest' --tests 'io.namastack.outbox.OutboxCoreAutoConfigurationTest' --no-daemon`
- [x] `./gradlew ktlintCheck --no-daemon`
- [x] `git diff --check`
- [x] `cd namastack-outbox-docs && npm ci`
- [x] `cd namastack-outbox-docs && npm run build` (only existing broken-anchor warnings in versioned documentation)
- [ ] `cd namastack-outbox-docs && npm run typecheck` (existing missing `window.dataLayer` type declaration in `CookieConsent.tsx`)
- [ ] `./gradlew clean build --no-build-cache --rerun-tasks` (unrelated Testcontainers environment failures: Mongo kernel incompatibility, Oracle PMON startup failure under ARM64 emulation, and SQL Server qemu segmentation fault)

The focused core tests and ktlint checks passed independently of the unrelated persistence and integration-test container failures.
